### PR TITLE
Added the form component for UCSBDiningCommonsMenuItem

### DIFF
--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,0 +1,31 @@
+const ucsbDiningCommonsMenuItemFixtures = {
+  oneMenuItem: {
+    id: 1,
+    diningCommonsCode: "ortega",
+    name: "Baked Pesto Pasta with Chicken",
+    station: "Entree Specials",
+  },
+
+  threeMenuItems: [
+    {
+      id: 1,
+      diningCommonsCode: "ortega",
+      name: "Baked Pesto Pasta with Chicken",
+      station: "Entree Specials",
+    },
+    {
+      id: 2,
+      diningCommonsCode: "ortega",
+      name: "Tofu Banh Mi Sandwich (v)",
+      station: "Entree Specials",
+    },
+    {
+      id: 3,
+      diningCommonsCode: "portola",
+      name: "Cream of Broccoli Soup (v)",
+      station: "Greens & Grains",
+    },
+  ],
+};
+
+export { ucsbDiningCommonsMenuItemFixtures };

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.jsx
@@ -1,0 +1,100 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function UCSBDiningCommonsMenuItemForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "UCSBDiningCommonsMenuItemForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="diningCommonsCode">Dining Commons Code</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-diningCommonsCode"}
+          id="diningCommonsCode"
+          type="text"
+          isInvalid={Boolean(errors.diningCommonsCode)}
+          {...register("diningCommonsCode", {
+            required: "Dining Commons Code is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.diningCommonsCode?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="name">Name</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-name"}
+          id="name"
+          type="text"
+          isInvalid={Boolean(errors.name)}
+          {...register("name", {
+            required: "Name is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.name?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="station">Station</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-station"}
+          id="station"
+          type="text"
+          isInvalid={Boolean(errors.station)}
+          {...register("station", {
+            required: "Station is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.station?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default UCSBDiningCommonsMenuItemForm;

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.jsx
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+export default {
+  title: "components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm",
+  component: UCSBDiningCommonsMenuItemForm,
+};
+
+const Template = (args) => {
+  return <UCSBDiningCommonsMenuItemForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: ucsbDiningCommonsMenuItemFixtures.oneMenuItem,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Dining Commons Code", "Name", "Station"];
+  const testId = "UCSBDiningCommonsMenuItemForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm
+            initialContents={ucsbDiningCommonsMenuItemFixtures.oneMenuItem}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Dining Commons Code is required/);
+    expect(screen.getByText(/Name is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Station is required/)).toBeInTheDocument();
+  });
+
+  test("No error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId(`${testId}-diningCommonsCode`);
+
+    const diningCommonsCodeField = screen.getByTestId(
+      `${testId}-diningCommonsCode`,
+    );
+    const nameField = screen.getByTestId(`${testId}-name`);
+    const stationField = screen.getByTestId(`${testId}-station`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(diningCommonsCodeField, {
+      target: { value: "ortega" },
+    });
+    fireEvent.change(nameField, {
+      target: { value: "Baked Pesto Pasta with Chicken" },
+    });
+    fireEvent.change(stationField, {
+      target: { value: "Entree Specials" },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(/Dining Commons Code is required/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Name is required/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Station is required/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
@@ -6,7 +6,6 @@ import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMen
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-
 const mockedNavigate = vi.fn();
 vi.mock("react-router", async () => {
   const originalModule = await vi.importActual("react-router");

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,134 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** This is a REST controller for UCSBDiningCommonsMenuItem */
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/UCSBDiningCommonsMenuItem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+  @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  /**
+   * List all UCSBDiningCommonsMenuItems
+   *
+   * @return an iterable of UCSBDiningCommonsMenuItems
+   */
+  @Operation(summary = "List all UCSB Dining Commons Menu Items")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItems() {
+    Iterable<UCSBDiningCommonsMenuItem> menuItems = ucsbDiningCommonsMenuItemRepository.findAll();
+    return menuItems;
+  }
+
+  /**
+   * Create a new UCSBDiningCommonsMenuItem
+   *
+   * @param diningCommonsCode code for the dining commons
+   * @param name name of the menu item
+   * @param station station where the item is served
+   * @return the saved UCSBDiningCommonsMenuItem
+   */
+  @Operation(summary = "Create a new UCSB Dining Commons Menu Item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+      @Parameter(name = "name") @RequestParam String name,
+      @Parameter(name = "station") @RequestParam String station) {
+
+    UCSBDiningCommonsMenuItem menuItem = new UCSBDiningCommonsMenuItem();
+    menuItem.setDiningCommonsCode(diningCommonsCode);
+    menuItem.setName(name);
+    menuItem.setStation(station);
+
+    UCSBDiningCommonsMenuItem savedMenuItem = ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+    return savedMenuItem;
+  }
+
+  /**
+   * Get a single UCSBDiningCommonsMenuItem by id
+   *
+   * @param id the id of the menu item
+   * @return the UCSBDiningCommonsMenuItem with the given id
+   */
+  @Operation(summary = "Get a single UCSB Dining Commons Menu Item")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public UCSBDiningCommonsMenuItem getById(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    return menuItem;
+  }
+
+  /**
+   * Update a single UCSBDiningCommonsMenuItem
+   *
+   * @param id id of the menu item to update
+   * @param incoming the new menu item values
+   * @return the updated menu item object
+   */
+  @Operation(summary = "Update a single UCSB Dining Commons Menu Item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public UCSBDiningCommonsMenuItem updateUCSBDiningCommonsMenuItem(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid UCSBDiningCommonsMenuItem incoming) {
+
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    menuItem.setDiningCommonsCode(incoming.getDiningCommonsCode());
+    menuItem.setName(incoming.getName());
+    menuItem.setStation(incoming.getStation());
+
+    ucsbDiningCommonsMenuItemRepository.save(menuItem);
+
+    return menuItem;
+  }
+
+  /**
+   * Delete a UCSBDiningCommonsMenuItem
+   *
+   * @param id the id of the menu item to delete
+   * @return a message indicating the menu item was deleted
+   */
+  @Operation(summary = "Delete a UCSB Dining Commons Menu Item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @DeleteMapping("")
+  public Object deleteUCSBDiningCommonsMenuItem(@Parameter(name = "id") @RequestParam Long id) {
+    UCSBDiningCommonsMenuItem menuItem =
+        ucsbDiningCommonsMenuItemRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(UCSBDiningCommonsMenuItem.class, id));
+
+    ucsbDiningCommonsMenuItemRepository.delete(menuItem);
+    return genericMessage("UCSBDiningCommonsMenuItem with id %s deleted".formatted(id));
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitems")
+public class UCSBDiningCommonsMenuItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,9 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,69 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItems-1",
+          "author": "CMWENDY",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEMS"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEMS_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEMS"
+              }
+            }
+          ]
+        }
+    }
+]}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,409 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/UCSBDiningCommonsMenuItem/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all")).andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc.perform(get("/api/UCSBDiningCommonsMenuItem/all")).andExpect(status().is(200));
+  }
+
+  // Authorization tests for /api/UCSBDiningCommonsMenuItem/post
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBDiningCommonsMenuItem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "Baked Pesto Pasta with Chicken")
+                .param("station", "Entree Specials")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/UCSBDiningCommonsMenuItem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "Baked Pesto Pasta with Chicken")
+                .param("station", "Entree Specials")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  // Tests with mocks for database actions
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsb_dining_commons_menu_items() throws Exception {
+
+    // arrange
+    UCSBDiningCommonsMenuItem menuItem1 =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(1L)
+            .diningCommonsCode("ortega")
+            .name("Baked Pesto Pasta with Chicken")
+            .station("Entree Specials")
+            .build();
+
+    UCSBDiningCommonsMenuItem menuItem2 =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(2L)
+            .diningCommonsCode("portola")
+            .name("Cream of Broccoli Soup (v)")
+            .station("Greens & Grains")
+            .build();
+
+    ArrayList<UCSBDiningCommonsMenuItem> expectedMenuItems = new ArrayList<>();
+    expectedMenuItems.addAll(Arrays.asList(menuItem1, menuItem2));
+
+    when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedMenuItems);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBDiningCommonsMenuItem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedMenuItems);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsb_dining_commons_menu_item() throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("ortega")
+            .name("Baked Pesto Pasta with Chicken")
+            .station("Entree Specials")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.save(eq(menuItem))).thenReturn(menuItem);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/UCSBDiningCommonsMenuItem/post")
+                    .param("diningCommonsCode", "ortega")
+                    .param("name", "Baked Pesto Pasta with Chicken")
+                    .param("station", "Entree Specials")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(menuItem);
+    String expectedJson = mapper.writeValueAsString(menuItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @Test
+  public void logged_out_users_cannot_get_by_id() throws Exception {
+    mockMvc
+        .perform(get("/api/UCSBDiningCommonsMenuItem").param("id", "7"))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+    // arrange
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(7L)
+            .diningCommonsCode("ortega")
+            .name("Baked Pesto Pasta with Chicken")
+            .station("Entree Specials")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.of(menuItem));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBDiningCommonsMenuItem").param("id", "7"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(menuItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+    // arrange
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/UCSBDiningCommonsMenuItem").param("id", "7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("UCSBDiningCommonsMenuItem with id 7 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_edit_an_existing_ucsb_dining_commons_menu_item() throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem originalMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(67L)
+            .diningCommonsCode("ortega")
+            .name("Baked Pesto Pasta with Chicken")
+            .station("Entree Specials")
+            .build();
+
+    UCSBDiningCommonsMenuItem editedMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(67L)
+            .diningCommonsCode("portola")
+            .name("Cream of Broccoli Soup (v)")
+            .station("Greens & Grains")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedMenuItem);
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L)))
+        .thenReturn(Optional.of(originalMenuItem));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBDiningCommonsMenuItem")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(67L));
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(editedMenuItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(requestBody, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_cannot_edit_ucsb_dining_commons_menu_item_that_does_not_exist()
+      throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem editedMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(67L)
+            .diningCommonsCode("portola")
+            .name("Cream of Broccoli Soup (v)")
+            .station("Greens & Grains")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedMenuItem);
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                put("/api/UCSBDiningCommonsMenuItem")
+                    .param("id", "67")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(eq(67L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBDiningCommonsMenuItem with id 67 not found", json.get("message"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_put() throws Exception {
+    UCSBDiningCommonsMenuItem editedMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(67L)
+            .diningCommonsCode("portola")
+            .name("Cream of Broccoli Soup (v)")
+            .station("Greens & Grains")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedMenuItem);
+
+    mockMvc
+        .perform(
+            put("/api/UCSBDiningCommonsMenuItem")
+                .param("id", "67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_put() throws Exception {
+    UCSBDiningCommonsMenuItem editedMenuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(67L)
+            .diningCommonsCode("portola")
+            .name("Cream of Broccoli Soup (v)")
+            .station("Greens & Grains")
+            .build();
+
+    String requestBody = mapper.writeValueAsString(editedMenuItem);
+
+    mockMvc
+        .perform(
+            put("/api/UCSBDiningCommonsMenuItem")
+                .param("id", "67")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("utf-8")
+                .content(requestBody)
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void admin_can_delete_a_ucsb_dining_commons_menu_item() throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem menuItem =
+        UCSBDiningCommonsMenuItem.builder()
+            .id(15L)
+            .diningCommonsCode("ortega")
+            .name("Baked Pesto Pasta with Chicken")
+            .station("Entree Specials")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.of(menuItem));
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBDiningCommonsMenuItem").param("id", "15").with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).delete(any());
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBDiningCommonsMenuItem with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void
+      admin_tries_to_delete_non_existent_ucsb_dining_commons_menu_item_and_gets_right_error_message()
+          throws Exception {
+    // arrange
+
+    when(ucsbDiningCommonsMenuItemRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(delete("/api/UCSBDiningCommonsMenuItem").param("id", "15").with(csrf()))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findById(15L);
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("UCSBDiningCommonsMenuItem with id 15 not found", json.get("message"));
+  }
+
+  @Test
+  public void logged_out_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBDiningCommonsMenuItem").param("id", "15").with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_delete() throws Exception {
+    mockMvc
+        .perform(delete("/api/UCSBDiningCommonsMenuItem").param("id", "15").with(csrf()))
+        .andExpect(status().is(403));
+  }
+}


### PR DESCRIPTION
## PR Description

This PR adds the form component for `UCSBDiningCommonsMenuItem`.

## What was added

- Created `UCSBDiningCommonsMenuItemForm`
- Supports both **Create** and **Update** use cases
- Form fields:
  - `diningCommonsCode`
  - `name`
  - `station`
- Displays `id` as read-only when editing existing records
- Added validation:
  - All fields are required (non-blank)
- Added Cancel button that navigates back
- Added Storybook stories:
  - Create
  - Update
- Added tests for:
  - Rendering (with and without initialContents)
  - Validation behavior
  - Cancel navigation
  - Successful submission

## Testing

- npm test
- npm run coverage
- npx stryker run

## Screenshots

<img width="1683" height="807" alt="Screenshot 2026-04-30 at 4 27 28 PM" src="https://github.com/user-attachments/assets/de57ba9c-6182-4917-949a-783296372ae1" />
<img width="1131" height="828" alt="Screenshot 2026-04-30 at 4 29 19 PM" src="https://github.com/user-attachments/assets/0141d502-5e39-4934-b36f-ee6bb1303b98" />

Storybook was tested locally using:

npm run storybook

The component will be visible on the published GitHub Pages Storybook after this PR is merged and the GitHub Pages workflow runs.

## Closes #4 