### PR TITLE
Add UCSBDiningCommonsMenuItem create page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,10 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
 import { hasRole, useCurrentUser } from "main/utils/useCurrentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -68,6 +72,31 @@ function App() {
           />
         </>
       )}
+
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route
+            exact
+            path="/diningcommonsmenuitem"
+            element={<UCSBDiningCommonsMenuItemIndexPage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/diningcommonsmenuitem/edit/:id"
+            element={<UCSBDiningCommonsMenuItemEditPage />}
+          />
+          <Route
+            exact
+            path="/diningcommonsmenuitem/create"
+            element={<UCSBDiningCommonsMenuItemCreatePage />}
+          />
+        </>
+      )}
+
       {hasRole(currentUser, "ROLE_USER") && (
         <>
           <Route exact path="/placeholder" element={<PlaceholderIndexPage />} />

--- a/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
+++ b/frontend/src/fixtures/ucsbDiningCommonsMenuItemFixtures.js
@@ -1,0 +1,31 @@
+const ucsbDiningCommonsMenuItemFixtures = {
+  oneMenuItem: {
+    id: 1,
+    diningCommonsCode: "ortega",
+    name: "Baked Pesto Pasta with Chicken",
+    station: "Entree Specials",
+  },
+
+  threeMenuItems: [
+    {
+      id: 1,
+      diningCommonsCode: "ortega",
+      name: "Baked Pesto Pasta with Chicken",
+      station: "Entree Specials",
+    },
+    {
+      id: 2,
+      diningCommonsCode: "ortega",
+      name: "Tofu Banh Mi Sandwich (v)",
+      station: "Entree Specials",
+    },
+    {
+      id: 3,
+      diningCommonsCode: "portola",
+      name: "Cream of Broccoli Soup (v)",
+      station: "Greens & Grains",
+    },
+  ],
+};
+
+export { ucsbDiningCommonsMenuItemFixtures };

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -68,6 +68,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/diningcommonsmenuitem">
+                    UCSBDiningCommonsMenuItem
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>

--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.jsx
@@ -1,0 +1,100 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function UCSBDiningCommonsMenuItemForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "UCSBDiningCommonsMenuItemForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="diningCommonsCode">Dining Commons Code</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-diningCommonsCode"}
+          id="diningCommonsCode"
+          type="text"
+          isInvalid={Boolean(errors.diningCommonsCode)}
+          {...register("diningCommonsCode", {
+            required: "Dining Commons Code is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.diningCommonsCode?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="name">Name</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-name"}
+          id="name"
+          type="text"
+          isInvalid={Boolean(errors.name)}
+          {...register("name", {
+            required: "Name is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.name?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="station">Station</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-station"}
+          id="station"
+          type="text"
+          isInvalid={Boolean(errors.station)}
+          {...register("station", {
+            required: "Station is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.station?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default UCSBDiningCommonsMenuItemForm;

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDiningCommonsMenuItemCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.jsx
@@ -1,11 +1,50 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemCreatePage({
+  storybook = false,
+}) {
+  const objectToAxiosParams = (menuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem/post",
+    method: "POST",
+    params: {
+      diningCommonsCode: menuItem.diningCommonsCode,
+      name: menuItem.name,
+      station: menuItem.station,
+    },
+  });
+
+  const onSuccess = (menuItem) => {
+    toast(
+      `New UCSBDiningCommonsMenuItem Created - id: ${menuItem.id} name: ${menuItem.name}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/UCSBDiningCommonsMenuItem/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBDiningCommonsMenuItem</h1>
+        <UCSBDiningCommonsMenuItemForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDiningCommonsMenuItemEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBDiningCommonsMenuItemIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/diningcommonsmenuitem/create">Create</a>
+        </p>
+        <p>
+          <a href="/diningcommonsmenuitem/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.jsx
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+export default {
+  title: "components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm",
+  component: UCSBDiningCommonsMenuItemForm,
+};
+
+const Template = (args) => {
+  return <UCSBDiningCommonsMenuItemForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: ucsbDiningCommonsMenuItemFixtures.oneMenuItem,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.stories.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage",
+  component: UCSBDiningCommonsMenuItemCreatePage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/UCSBDiningCommonsMenuItem/post", () => {
+      return HttpResponse.json(
+        {
+          id: 1,
+          diningCommonsCode: "ortega",
+          name: "Baked Pesto Pasta with Chicken",
+          station: "Entree Specials",
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm.test.jsx
@@ -1,0 +1,141 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["Dining Commons Code", "Name", "Station"];
+  const testId = "UCSBDiningCommonsMenuItemForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId(`${testId}-id`)).not.toBeInTheDocument();
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm
+            initialContents={ucsbDiningCommonsMenuItemFixtures.oneMenuItem}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+    expect(screen.getByTestId(`${testId}-id`)).toHaveValue("1");
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Dining Commons Code is required/);
+    expect(screen.getByText(/Name is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Station is required/)).toBeInTheDocument();
+  });
+
+  test("No error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBDiningCommonsMenuItemForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByTestId(`${testId}-diningCommonsCode`);
+
+    const diningCommonsCodeField = screen.getByTestId(
+      `${testId}-diningCommonsCode`,
+    );
+    const nameField = screen.getByTestId(`${testId}-name`);
+    const stationField = screen.getByTestId(`${testId}-station`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(diningCommonsCodeField, {
+      target: { value: "ortega" },
+    });
+    fireEvent.change(nameField, {
+      target: { value: "Baked Pesto Pasta with Chicken" },
+    });
+    fireEvent.change(stationField, {
+      target: { value: "Entree Specials" },
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(/Dining Commons Code is required/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Name is required/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Station is required/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
@@ -1,12 +1,55 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
-import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
-  const queryClient = new QueryClient();
+  const axiosMock = new AxiosMockAdapter(axios);
 
-  test("renders without crashing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMock.reset();
+    axiosMock.resetHistory();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -15,8 +58,78 @@ describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText("Create New UCSBDiningCommonsMenuItem"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText("Dining Commons Code")).toBeInTheDocument();
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Station")).toBeInTheDocument();
+  });
+
+  test("on submit, makes request to backend, and redirects to /diningcommonsmenuitem", async () => {
+    const queryClient = new QueryClient();
+
+    const menuItem = {
+      id: 3,
+      diningCommonsCode: "ortega",
+      name: "Baked Pesto Pasta with Chicken",
+      station: "Entree Specials",
+    };
+
+    axiosMock
+      .onPost("/api/UCSBDiningCommonsMenuItem/post")
+      .reply(202, menuItem);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Dining Commons Code")).toBeInTheDocument();
+    });
+
+    const diningCommonsCodeInput = screen.getByLabelText("Dining Commons Code");
+    const nameInput = screen.getByLabelText("Name");
+    const stationInput = screen.getByLabelText("Station");
+    const createButton = screen.getByText("Create");
+
+    fireEvent.change(diningCommonsCodeInput, {
+      target: { value: "ortega" },
+    });
+
+    fireEvent.change(nameInput, {
+      target: { value: "Baked Pesto Pasta with Chicken" },
+    });
+
+    fireEvent.change(stationInput, {
+      target: { value: "Entree Specials" },
+    });
+
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe(
+      "/api/UCSBDiningCommonsMenuItem/post",
+    );
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      diningCommonsCode: "ortega",
+      name: "Baked Pesto Pasta with Chicken",
+      station: "Entree Specials",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBDiningCommonsMenuItem Created - id: 3 name: Baked Pesto Pasta with Chicken",
+    );
+
+    expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
   });
 });

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemCreatePage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemCreatePage";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+describe("UCSBDiningCommonsMenuItemCreatePage tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -1,12 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
-import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
-  const queryClient = new QueryClient();
-
   test("renders without crashing", () => {
+    const queryClient = new QueryClient();
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
+  const queryClient = new QueryClient();
+
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Create")).toHaveAttribute(
+      "href",
+      "/diningcommonsmenuitem/create",
+    );
+
+    expect(screen.getByText("Edit")).toHaveAttribute(
+      "href",
+      "/diningcommonsmenuitem/edit/1",
+    );
+  });
+});


### PR DESCRIPTION
## Overview

This PR adds the create page for `UCSBDiningCommonsMenuItem`.

The page allows a user to create a new `UCSBDiningCommonsMenuItem` record by filling out the form and submitting valid data.

## Changes

- Replaced the placeholder create page with a working `UCSBDiningCommonsMenuItemCreatePage`
- Connected the create page to `UCSBDiningCommonsMenuItemForm`
- Sends valid form data to the backend endpoint:
  - `POST /api/UCSBDiningCommonsMenuItem/post`
- Redirects the user back to `/diningcommonsmenuitem` after a successful create
- Shows a toast message after a successful create
- Added tests for the create page
- Added a Storybook story for the create page
- Updated the edit page placeholder test so coverage stays at 100%

## Dependency Note

This branch includes the `UCSBDiningCommonsMenuItem` fixture/form dependency files because this branch was built from the placeholder branch before those dependency files were available on this branch.

## Screenshots

### Create Page

<img width="1298" height="421" alt="Screenshot 2026-05-03 at 11 42 29 PM" src="https://github.com/user-attachments/assets/a9439894-2411-4343-8e0a-c85c560bf243" />


### Swagger Verification

After submitting the form, I verified the created record using:

`GET /api/UCSBDiningCommonsMenuItem/all`

<img width="1145" height="774" alt="Screenshot 2026-05-03 at 11 43 10 PM" src="https://github.com/user-attachments/assets/1ecf78dd-57af-4d87-8abe-72e9ef8e131d" />

### Storybook Link

Will add published Storybook link here after the PR checks run

### Closes #7 