### PR TITLE
Add JS fixtures for Articles

### DIFF
--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -3,8 +3,7 @@ const articlesFixtures = {
     id: 1,
     title: "Using testing-playground with React Testing Library",
     url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
-    explanation:
-      "Helpful when we get to front end development",
+    explanation: "Helpful when we get to front end development",
     email: "phtcon@ucsb.edu",
     dateAdded: "2022-04-20T00:00:00",
   },

--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -1,0 +1,41 @@
+const articlesFixtures = {
+  oneArticle: {
+    id: 1,
+    title: "Using testing-playground with React Testing Library",
+    url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+    explanation:
+      "Helpful when we get to front end development",
+    email: "phtcon@ucsb.edu",
+    dateAdded: "2022-04-20T00:00:00",
+  },
+  threeArticles: [
+    {
+      id: 1,
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInhww&s=09",
+      explanation: "A lot of really useful classes are built into Spring",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-08T00:00:00",
+    },
+    {
+      id: 2,
+      title: "Hyper-modern Python",
+      url: "https://medium.com/@cjolowicz/hypermodern-python-d44485d9d769",
+      explanation:
+        "Tutorial on modern Python tooling, including pyenv, Poetry, and more",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-15T00:00:00",
+    },
+    {
+      id: 3,
+      title: "How To Use Pre-Commit To Automatically Correct Commits",
+      url: "https://lorenzwalthert.netlify.app/post/using-pre-commit-with-r/",
+      explanation:
+        "Setting up pre-commit hooks to automatically format and check code",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-19T00:00:00",
+    },
+  ],
+};
+
+export { articlesFixtures };


### PR DESCRIPTION
Adds `frontend/src/fixtures/articlesFixtures.js` with `oneArticle` and
`threeArticles` examples matching the JSON returned by the Articles
GET API (`id`, `title`, `url`, `explanation`, `email`, `dateAdded`),
following the style of `restaurantFixtures.js` and `ucsbDatesFixtures.js`

Closes #48 