### PR TITLE
Add ArticlesForm component, tests, and Storybook stories

### DIFF
--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -3,8 +3,7 @@ const articlesFixtures = {
     id: 1,
     title: "Using testing-playground with React Testing Library",
     url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
-    explanation:
-      "Helpful when we get to front end development",
+    explanation: "Helpful when we get to front end development",
     email: "phtcon@ucsb.edu",
     dateAdded: "2022-04-20T00:00:00",
   },

--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -1,0 +1,41 @@
+const articlesFixtures = {
+  oneArticle: {
+    id: 1,
+    title: "Using testing-playground with React Testing Library",
+    url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+    explanation:
+      "Helpful when we get to front end development",
+    email: "phtcon@ucsb.edu",
+    dateAdded: "2022-04-20T00:00:00",
+  },
+  threeArticles: [
+    {
+      id: 1,
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInhww&s=09",
+      explanation: "A lot of really useful classes are built into Spring",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-08T00:00:00",
+    },
+    {
+      id: 2,
+      title: "Hyper-modern Python",
+      url: "https://medium.com/@cjolowicz/hypermodern-python-d44485d9d769",
+      explanation:
+        "Tutorial on modern Python tooling, including pyenv, Poetry, and more",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-15T00:00:00",
+    },
+    {
+      id: 3,
+      title: "How To Use Pre-Commit To Automatically Correct Commits",
+      url: "https://lorenzwalthert.netlify.app/post/using-pre-commit-with-r/",
+      explanation:
+        "Setting up pre-commit hooks to automatically format and check code",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-19T00:00:00",
+    },
+  ],
+};
+
+export { articlesFixtures };

--- a/frontend/src/main/components/Articles/ArticlesForm.jsx
+++ b/frontend/src/main/components/Articles/ArticlesForm.jsx
@@ -1,0 +1,148 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function ArticlesForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "ArticlesForm";
+
+  // Stryker disable Regex
+  const url_regex = /^https?:\/\/.+/i;
+  // Stryker restore Regex
+
+  // Stryker disable Regex
+  const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-title"}
+          id="title"
+          type="text"
+          isInvalid={Boolean(errors.title)}
+          {...register("title", {
+            required: "Title is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.title?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="url">URL</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-url"}
+          id="url"
+          type="text"
+          isInvalid={Boolean(errors.url)}
+          {...register("url", {
+            required: "URL is required.",
+            pattern: {
+              value: url_regex,
+              message: "URL must start with http:// or https://",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.url?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-email"}
+          id="email"
+          type="email"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+            pattern: {
+              value: email_regex,
+              message: "Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateAdded">Date Added</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-dateAdded"}
+          id="dateAdded"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateAdded)}
+          {...register("dateAdded", {
+            required: "Date Added is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateAdded?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default ArticlesForm;

--- a/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+export default {
+  title: "components/Articles/ArticlesForm",
+  component: ArticlesForm,
+};
+
+const Template = (args) => {
+  return <ArticlesForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: articlesFixtures.oneArticle,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticlesForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Title",
+    "URL",
+    "Explanation",
+    "Email",
+    "Date Added",
+  ];
+  const testId = "ArticlesForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm initialContents={articlesFixtures.oneArticle} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Title is required/);
+    expect(screen.getByText(/URL is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Added is required/)).toBeInTheDocument();
+
+    const urlInput = screen.getByTestId(`${testId}-url`);
+    fireEvent.change(urlInput, { target: { value: "not-a-url" } });
+    const emailInput = screen.getByTestId(`${testId}-email`);
+    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/URL must start with http:\/\/ or https:\/\//),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+
+  test("No error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await screen.findByTestId(`${testId}-title`);
+
+    const titleField = screen.getByTestId(`${testId}-title`);
+    const urlField = screen.getByTestId(`${testId}-url`);
+    const explanationField = screen.getByTestId(`${testId}-explanation`);
+    const emailField = screen.getByTestId(`${testId}-email`);
+    const dateAddedField = screen.getByTestId(`${testId}-dateAdded`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(titleField, { target: { value: "Test Title" } });
+    fireEvent.change(urlField, { target: { value: "https://example.com" } });
+    fireEvent.change(explanationField, {
+      target: { value: "Test explanation" },
+    });
+    fireEvent.change(emailField, { target: { value: "test@ucsb.edu" } });
+    fireEvent.change(dateAddedField, {
+      target: { value: "2022-04-20T12:00" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(screen.queryByText(/Title is required/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/URL is required/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Explanation is required/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Email is required/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Date Added is required/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/URL must start with http:\/\/ or https:\/\//),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Email must be a valid email address/),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #49 

## Summary

Adds an `ArticlesForm` component (with tests and Storybook stories) modeled
on `RestaurantForm` and `UCSBDateForm`. Mirrors the fields of the
`Articles` database table and supports both create and edit flows via the
`initialContents`, `submitAction`, and `buttonLabel` props.

### Files added

- `frontend/src/main/components/Articles/ArticlesForm.jsx`
- `frontend/src/stories/components/Articles/ArticlesForm.stories.jsx`
- `frontend/src/tests/components/Articles/ArticlesForm.test.jsx`

<img width="1728" height="917" alt="image" src="https://github.com/user-attachments/assets/048087d4-a8b1-4484-9e72-8c8c88b92a25" />
<img width="1716" height="938" alt="image" src="https://github.com/user-attachments/assets/e0c05b2f-783b-4a9a-bc15-b4fd26a60ad5" />

https://ucsb-cs156-s26.github.io/team02-s26-08/prs/93/chromatic/?path=/story/components-articles-articlesform--create

Validated/tested with `npm test`,  `npx eslint src/main/components/Articles src/tests/components/Articles src/stories/components/Articles`, `npx prettier --check`, and  `npm run storybook` — manually verified `Create` and `Update` stories render and the date picker works