### PR TITLE
Add Articles placeholder pages and wire into App.jsx and AppNavbar

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,10 @@ import RestaurantIndexPage from "main/pages/Restaurants/RestaurantIndexPage";
 import RestaurantCreatePage from "main/pages/Restaurants/RestaurantCreatePage";
 import RestaurantEditPage from "main/pages/Restaurants/RestaurantEditPage";
 
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
@@ -65,6 +69,25 @@ function App() {
             exact
             path="/restaurants/create"
             element={<RestaurantCreatePage />}
+          />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_USER") && (
+        <>
+          <Route exact path="/articles" element={<ArticlesIndexPage />} />
+        </>
+      )}
+      {hasRole(currentUser, "ROLE_ADMIN") && (
+        <>
+          <Route
+            exact
+            path="/articles/edit/:id"
+            element={<ArticlesEditPage />}
+          />
+          <Route
+            exact
+            path="/articles/create"
+            element={<ArticlesCreatePage />}
           />
         </>
       )}

--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -3,8 +3,7 @@ const articlesFixtures = {
     id: 1,
     title: "Using testing-playground with React Testing Library",
     url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
-    explanation:
-      "Helpful when we get to front end development",
+    explanation: "Helpful when we get to front end development",
     email: "phtcon@ucsb.edu",
     dateAdded: "2022-04-20T00:00:00",
   },

--- a/frontend/src/fixtures/articlesFixtures.js
+++ b/frontend/src/fixtures/articlesFixtures.js
@@ -1,0 +1,41 @@
+const articlesFixtures = {
+  oneArticle: {
+    id: 1,
+    title: "Using testing-playground with React Testing Library",
+    url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+    explanation:
+      "Helpful when we get to front end development",
+    email: "phtcon@ucsb.edu",
+    dateAdded: "2022-04-20T00:00:00",
+  },
+  threeArticles: [
+    {
+      id: 1,
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300?t=gGXpmBH4y4eY9OBSUInhww&s=09",
+      explanation: "A lot of really useful classes are built into Spring",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-08T00:00:00",
+    },
+    {
+      id: 2,
+      title: "Hyper-modern Python",
+      url: "https://medium.com/@cjolowicz/hypermodern-python-d44485d9d769",
+      explanation:
+        "Tutorial on modern Python tooling, including pyenv, Poetry, and more",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-15T00:00:00",
+    },
+    {
+      id: 3,
+      title: "How To Use Pre-Commit To Automatically Correct Commits",
+      url: "https://lorenzwalthert.netlify.app/post/using-pre-commit-with-r/",
+      explanation:
+        "Setting up pre-commit hooks to automatically format and check code",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-19T00:00:00",
+    },
+  ],
+};
+
+export { articlesFixtures };

--- a/frontend/src/main/components/Articles/ArticlesForm.jsx
+++ b/frontend/src/main/components/Articles/ArticlesForm.jsx
@@ -1,0 +1,148 @@
+import { Button, Form } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function ArticlesForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "ArticlesForm";
+
+  // Stryker disable Regex
+  const url_regex = /^https?:\/\/.+/i;
+  // Stryker restore Regex
+
+  // Stryker disable Regex
+  const email_regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+  // Stryker restore Regex
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      {initialContents && (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="id">Id</Form.Label>
+          <Form.Control
+            data-testid={testIdPrefix + "-id"}
+            id="id"
+            type="text"
+            {...register("id")}
+            value={initialContents.id}
+            disabled
+          />
+        </Form.Group>
+      )}
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="title">Title</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-title"}
+          id="title"
+          type="text"
+          isInvalid={Boolean(errors.title)}
+          {...register("title", {
+            required: "Title is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.title?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="url">URL</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-url"}
+          id="url"
+          type="text"
+          isInvalid={Boolean(errors.url)}
+          {...register("url", {
+            required: "URL is required.",
+            pattern: {
+              value: url_regex,
+              message: "URL must start with http:// or https://",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.url?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="explanation">Explanation</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-explanation"}
+          id="explanation"
+          type="text"
+          isInvalid={Boolean(errors.explanation)}
+          {...register("explanation", {
+            required: "Explanation is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.explanation?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="email">Email</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-email"}
+          id="email"
+          type="email"
+          isInvalid={Boolean(errors.email)}
+          {...register("email", {
+            required: "Email is required.",
+            pattern: {
+              value: email_regex,
+              message: "Email must be a valid email address.",
+            },
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.email?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Form.Group className="mb-3">
+        <Form.Label htmlFor="dateAdded">Date Added</Form.Label>
+        <Form.Control
+          data-testid={testIdPrefix + "-dateAdded"}
+          id="dateAdded"
+          type="datetime-local"
+          isInvalid={Boolean(errors.dateAdded)}
+          {...register("dateAdded", {
+            required: "Date Added is required.",
+          })}
+        />
+        <Form.Control.Feedback type="invalid">
+          {errors.dateAdded?.message}
+        </Form.Control.Feedback>
+      </Form.Group>
+
+      <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+        {buttonLabel}
+      </Button>
+      <Button
+        variant="Secondary"
+        onClick={() => navigate(-1)}
+        data-testid={testIdPrefix + "-cancel"}
+      >
+        Cancel
+      </Button>
+    </Form>
+  );
+}
+
+export default ArticlesForm;

--- a/frontend/src/main/components/Articles/ArticlesTable.jsx
+++ b/frontend/src/main/components/Articles/ArticlesTable.jsx
@@ -1,0 +1,72 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/articlesUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function ArticlesTable({
+  articles,
+  currentUser,
+  testIdPrefix = "ArticlesTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/articles/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/Articles/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Title",
+      accessorKey: "title",
+    },
+    {
+      header: "URL",
+      accessorKey: "url",
+    },
+    {
+      header: "Explanation",
+      accessorKey: "explanation",
+    },
+    {
+      header: "Email",
+      accessorKey: "email",
+    },
+    {
+      header: "Date Added",
+      accessorKey: "dateAdded",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={articles} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/components/Nav/AppNavbar.jsx
+++ b/frontend/src/main/components/Nav/AppNavbar.jsx
@@ -62,6 +62,9 @@ export default function AppNavbar({
               )}
               {currentUser && currentUser.loggedIn ? (
                 <>
+                  <Nav.Link as={Link} to="/articles">
+                    Articles
+                  </Nav.Link>
                   <Nav.Link as={Link} to="/restaurants">
                     Restaurants
                   </Nav.Link>

--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesCreatePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesEditPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesIndexPage.jsx
@@ -1,0 +1,18 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ArticlesIndexPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p>
+          <a href="/articles/create">Create</a>
+        </p>
+        <p>
+          <a href="/articles/edit/1">Edit</a>
+        </p>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/utils/articlesUtils.js
+++ b/frontend/src/main/utils/articlesUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/Articles",
+    method: "DELETE",
+    params: {
+      id: cell.row.original.id,
+    },
+  };
+}

--- a/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticlesForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+export default {
+  title: "components/Articles/ArticlesForm",
+  component: ArticlesForm,
+};
+
+const Template = (args) => {
+  return <ArticlesForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: articlesFixtures.oneArticle,
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/Articles/ArticlesTable.stories.jsx
+++ b/frontend/src/stories/components/Articles/ArticlesTable.stories.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import ArticlesTable from "main/components/Articles/ArticlesTable";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/Articles/ArticlesTable",
+  component: ArticlesTable,
+};
+
+const Template = (args) => {
+  return <ArticlesTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  articles: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  articles: articlesFixtures.threeArticles,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+ThreeItemsAdminUser.args = {
+  articles: articlesFixtures.threeArticles,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/Articles", () => {
+      return HttpResponse.json(
+        { message: "Article deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticlesForm.test.jsx
@@ -1,0 +1,166 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticlesForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Title",
+    "URL",
+    "Explanation",
+    "Email",
+    "Date Added",
+  ];
+  const testId = "ArticlesForm";
+
+  test("renders correctly with no initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test("renders correctly when passing in initialContents", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm initialContents={articlesFixtures.oneArticle} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(await screen.findByTestId(`${testId}-id`)).toBeInTheDocument();
+    expect(screen.getByText(`Id`)).toBeInTheDocument();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByText(/Create/);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Title is required/);
+    expect(screen.getByText(/URL is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Explanation is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Email is required/)).toBeInTheDocument();
+    expect(screen.getByText(/Date Added is required/)).toBeInTheDocument();
+
+    const urlInput = screen.getByTestId(`${testId}-url`);
+    fireEvent.change(urlInput, { target: { value: "not-a-url" } });
+    const emailInput = screen.getByTestId(`${testId}-email`);
+    fireEvent.change(emailInput, { target: { value: "not-an-email" } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/URL must start with http:\/\/ or https:\/\//),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Email must be a valid email address/),
+    ).toBeInTheDocument();
+  });
+
+  test("No error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <ArticlesForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await screen.findByTestId(`${testId}-title`);
+
+    const titleField = screen.getByTestId(`${testId}-title`);
+    const urlField = screen.getByTestId(`${testId}-url`);
+    const explanationField = screen.getByTestId(`${testId}-explanation`);
+    const emailField = screen.getByTestId(`${testId}-email`);
+    const dateAddedField = screen.getByTestId(`${testId}-dateAdded`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(titleField, { target: { value: "Test Title" } });
+    fireEvent.change(urlField, { target: { value: "https://example.com" } });
+    fireEvent.change(explanationField, {
+      target: { value: "Test explanation" },
+    });
+    fireEvent.change(emailField, { target: { value: "test@ucsb.edu" } });
+    fireEvent.change(dateAddedField, {
+      target: { value: "2022-04-20T12:00" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(screen.queryByText(/Title is required/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/URL is required/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Explanation is required/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Email is required/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Date Added is required/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/URL must start with http:\/\/ or https:\/\//),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Email must be a valid email address/),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/Articles/ArticlesTable.test.jsx
+++ b/frontend/src/tests/components/Articles/ArticlesTable.test.jsx
@@ -1,0 +1,213 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import ArticlesTable from "main/components/Articles/ArticlesTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("ArticlesTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "id",
+    "Title",
+    "URL",
+    "Explanation",
+    "Email",
+    "Date Added",
+  ];
+  const expectedFields = [
+    "id",
+    "title",
+    "url",
+    "explanation",
+    "email",
+    "dateAdded",
+  ];
+  const testId = "ArticlesTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable articles={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable
+            articles={articlesFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-title`),
+    ).toHaveTextContent("Handy Spring Utility Classes");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-title`),
+    ).toHaveTextContent("Hyper-modern Python");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable
+            articles={articlesFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-title`),
+    ).toHaveTextContent("Handy Spring Utility Classes");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable
+            articles={articlesFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith("/articles/edit/1"),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/Articles")
+      .reply(200, { message: "Article deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesTable
+            articles={articlesFixtures.threeArticles}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesCreatePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+
+    await screen.findByText("Create page not yet implemented");
+    expect(
+      screen.getByText("Create page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { expect } from "vitest";
+
+describe("ArticlesEditPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Edit page not yet implemented");
+    expect(
+      screen.getByText("Edit page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import ArticlesIndexPage from "main/pages/Articles/ArticlesIndexPage";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ArticlesIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Index page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Index page not yet implemented"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Create")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/utils/articlesUtils.test.js
+++ b/frontend/src/tests/utils/articlesUtils.test.js
@@ -1,0 +1,34 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/articlesUtils";
+import { toast } from "react-toastify";
+
+vi.mock("react-toastify", () => ({
+  toast: vi.fn(),
+}));
+
+describe("articlesUtils tests", () => {
+  test("onDeleteSuccess calls toast and console.log", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    onDeleteSuccess("Article deleted");
+
+    expect(consoleSpy).toHaveBeenCalledWith("Article deleted");
+    expect(toast).toHaveBeenCalledWith("Article deleted");
+
+    consoleSpy.mockRestore();
+  });
+
+  test("cellToAxiosParamsDelete returns correct params", async () => {
+    const cell = { row: { original: { id: 17 } } };
+
+    const result = cellToAxiosParamsDelete(cell);
+
+    expect(result).toEqual({
+      url: "/api/Articles",
+      method: "DELETE",
+      params: { id: 17 },
+    });
+  });
+});


### PR DESCRIPTION
Closes #51

Adds temporary placeholder pages for Articles so routing and the navbar
can be exercised before real index/create/edit pages exist. Mirrors the
existing Placeholder and UCSBDiningCommonsMenuItem placeholder patterns.

### New pages

- `frontend/src/main/pages/Articles/ArticlesIndexPage.jsx` — placeholder
  index with links to `/articles/create` and `/articles/edit/1`
- `frontend/src/main/pages/Articles/ArticlesCreatePage.jsx` — create
  placeholder
- `frontend/src/main/pages/Articles/ArticlesEditPage.jsx` — edit
  placeholder

### New tests

- `frontend/src/tests/pages/Articles/ArticlesIndexPage.test.jsx`
- `frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx`
- `frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx`

### Routing and nav

- `frontend/src/App.jsx` — `ROLE_USER`: `/articles`; `ROLE_ADMIN`:
  `/articles/create`, `/articles/edit/:id`
- `frontend/src/main/components/Nav/AppNavbar.jsx` — **Articles** link
  to `/articles` when logged in

## Screenshot

<img width="1722" height="737" alt="image" src="https://github.com/user-attachments/assets/55964ff0-22b4-45b0-b898-306441b70e1a" />

Ran the following tests:
- `npm test` — all tests pass, 100% coverage
- `npx eslint` / Prettier on changed paths
- Manual: logged in, Articles in nav opens `/articles`; Create/Edit
      links behave like other placeholders (admin routes for create/edit)