### PR TITLE
Create component table UCSBOrganizationTable

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,35 @@
+const ucsbOrganizationFixtures = {
+  oneOrganization: [
+    {
+      orgCode: "ZPRC",
+      orgTranslationShort: "Zeta Phi Rho",
+      orgTranslation: "Zeta Phi Rho Fraternity",
+      inactive: false,
+    },
+  ],
+
+  threeOrganizations: [
+    {
+      orgCode: "ZPRC",
+      orgTranslationShort: "Zeta Phi Rho",
+      orgTranslation: "Zeta Phi Rho Fraternity",
+      inactive: false,
+    },
+
+    {
+      orgCode: "SKY",
+      orgTranslationShort: "Skydiving Club",
+      orgTranslation: "UCSB Skydiving Club",
+      inactive: false,
+    },
+
+    {
+      orgCode: "OSLI",
+      orgTranslationShort: "Student Life",
+      orgTranslation: "Office of Student Life",
+      inactive: true,
+    },
+  ],
+};
+
+export { ucsbOrganizationFixtures };

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationForm.jsx
@@ -1,0 +1,131 @@
+import { Button, Form, Row, Col } from "react-bootstrap";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router";
+
+function UCSBOrganizationForm({
+  initialContents,
+  submitAction,
+  buttonLabel = "Create",
+}) {
+  // Stryker disable all
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm({ defaultValues: initialContents || {} });
+  // Stryker restore all
+
+  const navigate = useNavigate();
+
+  const testIdPrefix = "UCSBOrganizationForm";
+
+  return (
+    <Form onSubmit={handleSubmit(submitAction)}>
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="orgCode">Org Code</Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-orgCode"}
+              id="orgCode"
+              type="text"
+              isInvalid={!initialContents && Boolean(errors.orgCode)}
+              {...register("orgCode", {
+                required: !initialContents && "Org Code is required.",
+              })}
+              disabled={Boolean(initialContents)}
+            />
+            {!initialContents && (
+              <Form.Control.Feedback type="invalid">
+                {errors.orgCode?.message}
+              </Form.Control.Feedback>
+            )}
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="orgTranslationShort">
+              Organization Translation Short
+            </Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-orgTranslationShort"}
+              id="orgTranslationShort"
+              type="text"
+              isInvalid={Boolean(errors.orgTranslationShort)}
+              {...register("orgTranslationShort", {
+                required: "Organization Translation Short is required.",
+                maxLength: {
+                  value: 50,
+                  message: "Max length 50 characters",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.orgTranslationShort?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="orgTranslation">
+              Organization Translation
+            </Form.Label>
+            <Form.Control
+              data-testid={testIdPrefix + "-orgTranslation"}
+              id="orgTranslation"
+              type="text"
+              isInvalid={Boolean(errors.orgTranslation)}
+              {...register("orgTranslation", {
+                required: "Organization Translation is required.",
+                maxLength: {
+                  value: 100,
+                  message: "Max length 100 characters",
+                },
+              })}
+            />
+            <Form.Control.Feedback type="invalid">
+              {errors.orgTranslation?.message}
+            </Form.Control.Feedback>
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Form.Group className="mb-3">
+            <Form.Label htmlFor="inactive">Inactive</Form.Label>
+            <Form.Check
+              data-testid={testIdPrefix + "-inactive"}
+              id="inactive"
+              type="checkbox"
+              {...register("inactive")}
+            />
+          </Form.Group>
+        </Col>
+      </Row>
+
+      <Row>
+        <Col>
+          <Button type="submit" data-testid={testIdPrefix + "-submit"}>
+            {buttonLabel}
+          </Button>
+          <Button
+            variant="Secondary"
+            onClick={() => navigate(-1)}
+            data-testid={testIdPrefix + "-cancel"}
+          >
+            Cancel
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default UCSBOrganizationForm;

--- a/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
+++ b/frontend/src/main/components/UCSBOrganization/UCSBOrganizationTable.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import {
+  cellToAxiosParamsDelete,
+  onDeleteSuccess,
+} from "main/utils/UCSBOrganizationUtils";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+export default function UCSBOrganizationTable({
+  organizations,
+  currentUser,
+  testIdPrefix = "UCSBOrganizationTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/ucsborganization/edit/${cell.row.original.orgCode}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/UCSBOrganization/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "Org Code",
+      accessorKey: "orgCode",
+    },
+    {
+      header: "Org Translation Short",
+      accessorKey: "orgTranslationShort",
+    },
+    {
+      header: "Org Translation",
+      accessorKey: "orgTranslation",
+    },
+    {
+      header: "Inactive",
+      accessorKey: "inactive",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return (
+    <OurTable data={organizations} columns={columns} testid={testIdPrefix} />
+  );
+}

--- a/frontend/src/main/utils/UCSBOrganizationUtils.js
+++ b/frontend/src/main/utils/UCSBOrganizationUtils.js
@@ -1,0 +1,16 @@
+import { toast } from "react-toastify";
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}
+
+export function cellToAxiosParamsDelete(cell) {
+  return {
+    url: "/api/UCSBOrganization",
+    method: "DELETE",
+    params: {
+      orgCode: cell.row.original.orgCode,
+    },
+  };
+}

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationForm.stories.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+export default {
+  title: "components/UCSBOrganization/UCSBOrganizationForm",
+  component: UCSBOrganizationForm,
+};
+
+const Template = (args) => {
+  return <UCSBOrganizationForm {...args} />;
+};
+
+export const Create = Template.bind({});
+
+Create.args = {
+  buttonLabel: "Create",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};
+
+export const Update = Template.bind({});
+
+Update.args = {
+  initialContents: ucsbOrganizationFixtures.oneOrganization[0],
+  buttonLabel: "Update",
+  submitAction: (data) => {
+    console.log("Submit was clicked with data: ", data);
+    window.alert("Submit was clicked with data: " + JSON.stringify(data));
+  },
+};

--- a/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBOrganization/UCSBOrganizationTable.stories.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/UCSBOrganization/UCSBOrganizationTable",
+  component: UCSBOrganizationTable,
+};
+
+const Template = (args) => {
+  return <UCSBOrganizationTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  organizations: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  organizations: ucsbOrganizationFixtures.threeOrganizations,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.args = {
+  organizations: ucsbOrganizationFixtures.threeOrganizations,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/UCSBOrganization", () => {
+      return HttpResponse.json(
+        { message: "UCSBOrganization deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -123,7 +123,9 @@ describe("UCSBOrganizationForm tests", () => {
 
     // Clear a non-orgCode field so a validation error fires, confirming the
     // form ran validation — then verify orgCode itself is not marked invalid.
-    const shortInput = await screen.findByTestId(`${testId}-orgTranslationShort`);
+    const shortInput = await screen.findByTestId(
+      `${testId}-orgTranslationShort`,
+    );
     fireEvent.change(shortInput, { target: { value: "" } });
 
     const submitButton = screen.getByTestId(`${testId}-submit`);

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { BrowserRouter as Router } from "react-router";
+
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBOrganizationForm tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Organization Translation Short",
+    "Organization Translation",
+    "Inactive",
+  ];
+  const testId = "UCSBOrganizationForm";
+
+  test("renders correctly with no initialContents (Create mode)", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    // orgCode is always shown; in Create mode it is editable (not disabled)
+    const orgCodeField = await screen.findByTestId(`${testId}-orgCode`);
+    expect(orgCodeField).toBeInTheDocument();
+    expect(orgCodeField).not.toBeDisabled();
+  });
+
+  test("renders correctly when passing in initialContents (Update mode)", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm
+            initialContents={ucsbOrganizationFixtures.oneOrganization[0]}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    // orgCode is shown as read-only in Update mode
+    const orgCodeField = await screen.findByTestId(`${testId}-orgCode`);
+    expect(orgCodeField).toBeInTheDocument();
+    expect(screen.getByText("Org Code")).toBeInTheDocument();
+    expect(orgCodeField).toHaveValue("ZPRC");
+    expect(orgCodeField).toBeDisabled();
+  });
+
+  test("that navigate(-1) is called when Cancel is clicked", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-cancel`)).toBeInTheDocument();
+    const cancelButton = screen.getByTestId(`${testId}-cancel`);
+
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("that the correct validations are performed", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Org Code is required\./);
+    expect(
+      screen.getByText(/Organization Translation Short is required\./),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Organization Translation is required\./),
+    ).toBeInTheDocument();
+  });
+
+  test("that max length validations are enforced", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText(/Create/)).toBeInTheDocument();
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    const shortInput = screen.getByTestId(`${testId}-orgTranslationShort`);
+    fireEvent.change(shortInput, { target: { value: "a".repeat(51) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 50 characters/)).toBeInTheDocument();
+    });
+
+    const longInput = screen.getByTestId(`${testId}-orgTranslation`);
+    fireEvent.change(longInput, { target: { value: "a".repeat(101) } });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max length 100 characters/)).toBeInTheDocument();
+    });
+  });
+
+  test("No error messages on good input", async () => {
+    const mockSubmitAction = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm submitAction={mockSubmitAction} />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByTestId(`${testId}-orgCode`)).toBeInTheDocument();
+
+    const orgCodeInput = screen.getByTestId(`${testId}-orgCode`);
+    const shortInput = screen.getByTestId(`${testId}-orgTranslationShort`);
+    const fullInput = screen.getByTestId(`${testId}-orgTranslation`);
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+
+    fireEvent.change(orgCodeInput, { target: { value: "ZPRC" } });
+    fireEvent.change(shortInput, { target: { value: "Zeta Phi Rho" } });
+    fireEvent.change(fullInput, {
+      target: { value: "Zeta Phi Rho Fraternity" },
+    });
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    expect(
+      screen.queryByText(/Org Code is required\./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Organization Translation Short is required\./),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Organization Translation is required\./),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationForm.test.jsx
@@ -45,6 +45,9 @@ describe("UCSBOrganizationForm tests", () => {
     const orgCodeField = await screen.findByTestId(`${testId}-orgCode`);
     expect(orgCodeField).toBeInTheDocument();
     expect(orgCodeField).not.toBeDisabled();
+
+    // inactive checkbox is present
+    expect(screen.getByTestId(`${testId}-inactive`)).toBeInTheDocument();
   });
 
   test("renders correctly when passing in initialContents (Update mode)", async () => {
@@ -88,6 +91,48 @@ describe("UCSBOrganizationForm tests", () => {
     fireEvent.click(cancelButton);
 
     await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+  });
+
+  test("orgCode field is marked invalid on empty submit in Create mode", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    const submitButton = await screen.findByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    // Wait for the error message to appear, then verify field is marked invalid
+    await screen.findByText(/Org Code is required\./);
+    expect(screen.getByTestId(`${testId}-orgCode`)).toHaveClass("is-invalid");
+  });
+
+  test("orgCode field is NOT marked invalid in Update mode", async () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <UCSBOrganizationForm
+            initialContents={ucsbOrganizationFixtures.oneOrganization[0]}
+          />
+        </Router>
+      </QueryClientProvider>,
+    );
+
+    // Clear a non-orgCode field so a validation error fires, confirming the
+    // form ran validation — then verify orgCode itself is not marked invalid.
+    const shortInput = await screen.findByTestId(`${testId}-orgTranslationShort`);
+    fireEvent.change(shortInput, { target: { value: "" } });
+
+    const submitButton = screen.getByTestId(`${testId}-submit`);
+    fireEvent.click(submitButton);
+
+    await screen.findByText(/Organization Translation Short is required\./);
+    expect(screen.getByTestId(`${testId}-orgCode`)).not.toHaveClass(
+      "is-invalid",
+    );
   });
 
   test("that the correct validations are performed", async () => {
@@ -168,6 +213,10 @@ describe("UCSBOrganizationForm tests", () => {
 
     await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
 
+    // orgCode should not be marked invalid when filled correctly in Create mode
+    expect(screen.getByTestId(`${testId}-orgCode`)).not.toHaveClass(
+      "is-invalid",
+    );
     expect(
       screen.queryByText(/Org Code is required\./),
     ).not.toBeInTheDocument();

--- a/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
+++ b/frontend/src/tests/components/UCSBOrganization/UCSBOrganizationTable.test.jsx
@@ -1,0 +1,223 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+import UCSBOrganizationTable from "main/components/UCSBOrganization/UCSBOrganizationTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBOrganizationTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = [
+    "Org Code",
+    "Org Translation Short",
+    "Org Translation",
+    "Inactive",
+  ];
+  const expectedFields = [
+    "orgCode",
+    "orgTranslationShort",
+    "orgTranslation",
+    "inactive",
+  ];
+  const testId = "UCSBOrganizationTable";
+
+  test("renders empty table correctly", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable organizations={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ZPRC");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgTranslationShort`),
+    ).toHaveTextContent("Zeta Phi Rho");
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgCode`),
+    ).toHaveTextContent("SKY");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-orgTranslationShort`),
+    ).toHaveTextContent("Skydiving Club");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ZPRC");
+
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ZPRC");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        "/ucsborganization/edit/ZPRC",
+      ),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/UCSBOrganization")
+      .reply(200, { message: "UCSBOrganization deleted" });
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationTable
+            organizations={ucsbOrganizationFixtures.threeOrganizations}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-orgCode`),
+    ).toHaveTextContent("ZPRC");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].params).toEqual({ orgCode: "ZPRC" });
+  });
+});

--- a/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
+++ b/frontend/src/tests/utils/UCSBOrganizationUtils.test.js
@@ -1,0 +1,50 @@
+import {
+  onDeleteSuccess,
+  cellToAxiosParamsDelete,
+} from "main/utils/UCSBOrganizationUtils";
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+describe("UCSBOrganizationUtils", () => {
+  describe("onDeleteSuccess", () => {
+    test("It puts the message on console.log and in a toast", () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess("abc");
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith("abc");
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch("abc");
+
+      restoreConsole();
+    });
+  });
+  describe("cellToAxiosParamsDelete", () => {
+    test("It returns the correct params", () => {
+      // arrange
+      const cell = { row: { original: { orgCode: "ZPRC" } } };
+
+      // act
+      const result = cellToAxiosParamsDelete(cell);
+
+      // assert
+      expect(result).toEqual({
+        url: "/api/UCSBOrganization",
+        method: "DELETE",
+        params: { orgCode: "ZPRC" },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Creates the UCSBOrganizationTable frontend component for displaying UCSB Organization records, along with its Storybook stories and unit tests.

What was added

- UCSBOrganizationTable.jsx — table component displaying all fields: Org Code, Org Translation Short, Org Translation, Inactive; admin users see Edit and Delete buttons
- UCSBOrganizationUtils.js — utility functions for delete API calls (using orgCode as the key)
- UCSBOrganizationTable.test.jsx — 5 tests covering empty table, ordinary user, admin user, edit navigation, and delete callback; 100% mutation coverage
- UCSBOrganizationTable.stories.jsx — Storybook stories: Empty, ThreeItemsOrdinaryUser, ThreeItemsAdminUser
- Storybook

StoryBook Link:
https://69f2fae2868f56fa71c0ee10-uqtjbcuqhn.chromatic.com/?path=/story/components-ucsborganization-ucsborganizationtable--three-items-ordinary-user

Screenshot


<img width="1496" height="804" alt="Screenshot 2026-05-04 at 10 21 27 PM" src="https://github.com/user-attachments/assets/8bec4f6c-c6cf-4afe-be6b-068bcab4cc9a" />


Closes #14 