### PR TITLE
Articles: create page, tests, and Storybook

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesCreatePage.jsx
@@ -1,11 +1,48 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (article) => ({
+    url: "/api/Articles/post",
+    method: "POST",
+    params: {
+      title: article.title,
+      url: article.url,
+      explanation: article.explanation,
+      email: article.email,
+      dateAdded: article.dateAdded,
+    },
+  });
+
+  const onSuccess = (article) => {
+    toast(`New Article Created - id: ${article.id} title: ${article.title}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/Articles/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Article</h1>
+        <ArticlesForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesCreatePage.stories.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
+
+export default {
+  title: "pages/Articles/ArticlesCreatePage",
+  component: ArticlesCreatePage,
+};
+
+const Template = () => <ArticlesCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/Articles/post", () => {
+      return HttpResponse.json(
+        {
+          id: 1,
+          title: "Using testing-playground with React Testing Library",
+          url: "https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7",
+          explanation: "Helpful when we get to front end development",
+          email: "phtcon@ucsb.edu",
+          dateAdded: "2022-04-20T00:00:00",
+        },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ArticlesCreatePage from "main/pages/Articles/ArticlesCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("ArticlesCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,15 +43,10 @@ describe("ArticlesCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-
-    setupUserOnly();
-
-    // act
+  test("renders without crashing", async () => {
+    const queryClient = new QueryClient();
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -38,11 +55,97 @@ describe("ArticlesCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
+    await waitFor(() => {
+      expect(screen.getByText("Create New Article")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    expect(screen.getByLabelText("URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Explanation")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    expect(screen.getByLabelText("Date Added")).toBeInTheDocument();
+  });
 
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+  test("on submit, makes request to backend, and redirects to /articles", async () => {
+    const queryClient = new QueryClient();
+    const savedArticle = {
+      id: 3,
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300",
+      explanation: "Useful Spring classes",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-08T12:00:00",
+    };
+
+    axiosMock.onPost("/api/Articles/post").reply(202, savedArticle);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Title")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Handy Spring Utility Classes" },
+    });
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: {
+        value: "https://twitter.com/maciejwalkowiak/status/1511736828369719300",
+      },
+    });
+    fireEvent.change(screen.getByLabelText("Explanation"), {
+      target: { value: "Useful Spring classes" },
+    });
+    fireEvent.change(screen.getByLabelText("Email"), {
+      target: { value: "phtcon@ucsb.edu" },
+    });
+    fireEvent.change(screen.getByLabelText("Date Added"), {
+      target: { value: "2022-04-08T12:00" },
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].url).toBe("/api/Articles/post");
+    expect(axiosMock.history.post[0].params).toEqual({
+      title: "Handy Spring Utility Classes",
+      url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300",
+      explanation: "Useful Spring classes",
+      email: "phtcon@ucsb.edu",
+      dateAdded: "2022-04-08T12:00",
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New Article Created - id: 3 title: Handy Spring Utility Classes",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/articles" });
+  });
+
+  test("when form is invalid, does not POST and shows validation messages", async () => {
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ArticlesCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Create New Article")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Create"));
+
+    await screen.findByText(/Title is required/);
+    expect(screen.getByText(/URL is required/)).toBeInTheDocument();
+    expect(axiosMock.history.post.length).toBe(0);
   });
 });


### PR DESCRIPTION
This PR implements the Articles create flow. ArticlesCreatePage uses useBackendMutation to POST /api/Articles/post with query params title, url, explanation, email, and dateAdded, shows a success toast including the new id and title, invalidates ["/api/Articles/all"], and navigates to /articles after a successful create (unless storybook={true}).

Tested creating an article locally and confirmed it showed up in the swagger Get endpoint.

<img width="1376" height="722" alt="image" src="https://github.com/user-attachments/assets/47c0b880-0251-448c-b20a-051c0a068c42" />
<img width="1538" height="670" alt="image" src="https://github.com/user-attachments/assets/babb5b4e-3723-456a-a981-2e86ee36fb5f" />

Closes #52