### PR TITLE
Create edit page for UCSBOrganization

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -1,11 +1,77 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: organization,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/UCSBOrganization?orgCode=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/UCSBOrganization`,
+      params: {
+        orgCode: id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (organization) => ({
+    url: "/api/UCSBOrganization",
+    method: "PUT",
+    params: {
+      orgCode: id,
+    },
+    data: {
+      orgTranslationShort: organization.orgTranslationShort,
+      orgTranslation: organization.orgTranslation,
+      inactive: organization.inactive,
+    },
+  });
+
+  const onSuccess = (organization) => {
+    toast(
+      `UCSBOrganization Updated - orgCode: ${organization.orgCode}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBOrganization?orgCode=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBOrganization</h1>
+        {organization && (
+          <UCSBOrganizationForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialContents={organization}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationEditPage.jsx
@@ -39,9 +39,7 @@ export default function UCSBOrganizationEditPage({ storybook = false }) {
   });
 
   const onSuccess = (organization) => {
-    toast(
-      `UCSBOrganization Updated - orgCode: ${organization.orgCode}`,
-    );
+    toast(`UCSBOrganization Updated - orgCode: ${organization.orgCode}`);
   };
 
   const mutation = useBackendMutation(

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { ucsbOrganizationFixtures } from "fixtures/ucsbOrganizationFixtures";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationEditPage",
+  component: UCSBOrganizationEditPage,
+};
+
+const Template = () => <UCSBOrganizationEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBOrganization", () => {
+      return HttpResponse.json(ucsbOrganizationFixtures.threeOrganizations[0], {
+        status: 200,
+      });
+    }),
+    http.put("/api/UCSBOrganization", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationEditPage.test.jsx
@@ -1,46 +1,210 @@
-import { render, screen } from "@testing-library/react";
-import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBOrganizationEditPage from "main/pages/UCSBOrganization/UCSBOrganizationEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+import mockConsole from "tests/testutils/mockConsole";
 
-describe("UCSBOrganizationEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
   };
+});
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-    setupUserOnly();
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: "ZPRC",
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBOrganizationEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+let axiosMock;
+describe("UCSBOrganizationEditPage tests", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "ZPRC" } })
+        .timeout();
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit UCSBOrganization");
+      expect(
+        screen.queryByTestId("UCSBOrganizationForm-orgCode"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBOrganization", { params: { orgCode: "ZPRC" } })
+        .reply(200, {
+          orgCode: "ZPRC",
+          orgTranslationShort: "Zeta Phi Rho",
+          orgTranslation: "Zeta Phi Rho Fraternity",
+          inactive: false,
+        });
+      axiosMock.onPut("/api/UCSBOrganization").reply(200, {
+        orgCode: "ZPRC",
+        orgTranslationShort: "Zeta Phi Rho Updated",
+        orgTranslation: "Zeta Phi Rho Fraternity Updated",
+        inactive: true,
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgCodeField = screen.getByTestId("UCSBOrganizationForm-orgCode");
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgCodeField).toBeInTheDocument();
+      expect(orgCodeField).toHaveValue("ZPRC");
+      expect(orgTranslationShortField).toBeInTheDocument();
+      expect(orgTranslationShortField).toHaveValue("Zeta Phi Rho");
+      expect(orgTranslationField).toBeInTheDocument();
+      expect(orgTranslationField).toHaveValue("Zeta Phi Rho Fraternity");
+
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(orgTranslationShortField, {
+        target: { value: "Zeta Phi Rho Updated" },
+      });
+      fireEvent.change(orgTranslationField, {
+        target: { value: "Zeta Phi Rho Fraternity Updated" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization Updated - orgCode: ZPRC",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ orgCode: "ZPRC" });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          orgTranslationShort: "Zeta Phi Rho Updated",
+          orgTranslation: "Zeta Phi Rho Fraternity Updated",
+          inactive: false,
+        }),
+      );
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBOrganizationEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("UCSBOrganizationForm-orgCode");
+
+      const orgTranslationShortField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslationShort",
+      );
+      const orgTranslationField = screen.getByTestId(
+        "UCSBOrganizationForm-orgTranslation",
+      );
+      const submitButton = screen.getByTestId("UCSBOrganizationForm-submit");
+
+      expect(orgTranslationShortField).toHaveValue("Zeta Phi Rho");
+      expect(orgTranslationField).toHaveValue("Zeta Phi Rho Fraternity");
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.change(orgTranslationShortField, {
+        target: { value: "Zeta Phi Rho Updated" },
+      });
+      fireEvent.change(orgTranslationField, {
+        target: { value: "Zeta Phi Rho Fraternity Updated" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBOrganization Updated - orgCode: ZPRC",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
+    });
   });
 });


### PR DESCRIPTION
Reads orgCode from URL params (:id)
Fetches the record from GET /api/UCSBOrganization?orgCode={id}
On submit, calls PUT /api/UCSBOrganization?orgCode={id} with updated fields (orgTranslationShort, orgTranslation, inactive)
Shows a toast on success and navigates back to /ucsborganization
Cancel button navigates back via browser history (handled in the form)
UCSBOrganizationEditPage.test.jsx — 3 tests:

Backend timeout → renders header but no form
Form is pre-populated with existing data; submit fires PUT and shows toast, then navigates
Second "Changes when you click Update" test verifying same flow


<img width="1193" height="450" alt="Screenshot 2026-05-05 at 4 32 34 PM" src="https://github.com/user-attachments/assets/c11dd340-8601-4e9c-ba79-13b3a9805541" />

Closes #18 