### PR TITLE
Implement Articles edit page with GET/PUT, tests, and Storybook for issue #54

### DIFF
--- a/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
+++ b/frontend/src/main/pages/Articles/ArticlesEditPage.jsx
@@ -1,11 +1,78 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Navigate, useParams } from "react-router";
+import ArticlesForm from "main/components/Articles/ArticlesForm";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function ArticlesEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function ArticlesEditPage({ storybook = false }) {
+  let { id } = useParams();
+
+  const {
+    data: article,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/Articles?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so mutating this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/Articles`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (articleData) => ({
+    url: "/api/Articles",
+    method: "PUT",
+    params: {
+      id: articleData.id,
+    },
+    data: {
+      title: articleData.title,
+      url: articleData.url,
+      explanation: articleData.explanation,
+      email: articleData.email,
+      dateAdded: articleData.dateAdded,
+    },
+  });
+
+  const onSuccess = (updatedArticle) => {
+    toast(
+      `Article Updated - id: ${updatedArticle.id} title: ${updatedArticle.title}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/Articles?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/articles" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit Article</h1>
+        {article && (
+          <ArticlesForm
+            initialContents={article}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
+++ b/frontend/src/stories/pages/Articles/ArticlesEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { articlesFixtures } from "fixtures/articlesFixtures";
+import { http, HttpResponse } from "msw";
+
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+
+export default {
+  title: "pages/Articles/ArticlesEditPage",
+  component: ArticlesEditPage,
+};
+
+const Template = () => <ArticlesEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/Articles", () => {
+      return HttpResponse.json(articlesFixtures.oneArticle, {
+        status: 200,
+      });
+    }),
+    http.put("/api/Articles", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
+++ b/frontend/src/tests/pages/Articles/ArticlesEditPage.test.jsx
@@ -1,47 +1,254 @@
-import { render, screen } from "@testing-library/react";
-import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import ArticlesEditPage from "main/pages/Articles/ArticlesEditPage";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+import mockConsole from "tests/testutils/mockConsole";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigateTo = vi.fn();
+const mockNavigateRelative = vi.fn();
+
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: "17",
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigateTo(x);
+      return null;
+    }),
+    useNavigate: () => mockNavigateRelative,
+  };
+});
+
+const getArticle = () => ({
+  id: 17,
+  title: "Handy Spring Utility Classes",
+  url: "https://twitter.com/maciejwalkowiak/status/1511736828369719300",
+  explanation: "Useful Spring classes",
+  email: "phtcon@ucsb.edu",
+  dateAdded: "2022-04-08T12:00:00",
+});
+
+let axiosMock;
 
 describe("ArticlesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock.onGet("/api/Articles", { params: { id: "17" } }).timeout();
+    });
 
-  const setupUserOnly = () => {
-    axiosMock.reset();
-    axiosMock.resetHistory();
-    axiosMock
-      .onGet("/api/currentUser")
-      .reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock
-      .onGet("/api/systemInfo")
-      .reply(200, systemInfoFixtures.showingNeither);
-  };
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigateTo.mockClear();
+      mockNavigateRelative.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
 
-  const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
+    const queryClient = new QueryClient();
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    setupUserOnly();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Article");
+      expect(
+        screen.queryByTestId("ArticlesForm-title"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
+  });
 
-    // act
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <ArticlesEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/Articles", { params: { id: "17" } })
+        .reply(200, getArticle());
+      axiosMock.onPut("/api/Articles").reply(200, {
+        id: "17",
+        title: "Updated Article Title",
+        url: "https://example.com/article",
+        explanation: "Updated explanation",
+        email: "updated@ucsb.edu",
+        dateAdded: "2022-06-01T09:00:00",
+      });
+    });
 
-    // assert
-    await screen.findByText("Edit page not yet implemented");
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigateTo.mockClear();
+      mockNavigateRelative.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-id");
+
+      expect(screen.getByTestId("ArticlesForm-id")).toHaveValue("17");
+      expect(screen.getByTestId("ArticlesForm-title")).toHaveValue(
+        "Handy Spring Utility Classes",
+      );
+      expect(screen.getByTestId("ArticlesForm-url")).toHaveValue(
+        "https://twitter.com/maciejwalkowiak/status/1511736828369719300",
+      );
+      expect(screen.getByTestId("ArticlesForm-explanation")).toHaveValue(
+        "Useful Spring classes",
+      );
+      expect(screen.getByTestId("ArticlesForm-email")).toHaveValue(
+        "phtcon@ucsb.edu",
+      );
+
+      const submitButton = screen.getByTestId("ArticlesForm-submit");
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(screen.getByTestId("ArticlesForm-title"), {
+        target: { value: "Updated Article Title" },
+      });
+      fireEvent.change(screen.getByTestId("ArticlesForm-url"), {
+        target: { value: "https://example.com/article" },
+      });
+      fireEvent.change(screen.getByTestId("ArticlesForm-explanation"), {
+        target: { value: "Really big explanations" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: Updated Article Title",
+      );
+
+      expect(mockNavigateTo).toBeCalledWith({ to: "/articles" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          title: "Updated Article Title",
+          url: "https://example.com/article",
+          explanation: "Really big explanations",
+          email: "phtcon@ucsb.edu",
+          dateAdded: "2022-04-08T12:00:00",
+        }),
+      );
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-id");
+
+      fireEvent.change(screen.getByTestId("ArticlesForm-title"), {
+        target: { value: "Updated Article Title" },
+      });
+      fireEvent.change(screen.getByTestId("ArticlesForm-url"), {
+        target: { value: "https://example.com/article" },
+      });
+      fireEvent.change(screen.getByTestId("ArticlesForm-explanation"), {
+        target: { value: "New explanation" },
+      });
+
+      fireEvent.click(screen.getByTestId("ArticlesForm-submit"));
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalled());
+      expect(mockToast).toBeCalledWith(
+        "Article Updated - id: 17 title: Updated Article Title",
+      );
+      expect(mockNavigateTo).toBeCalledWith({ to: "/articles" });
+    });
+
+    test("does not PUT when form is invalid", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-title");
+
+      fireEvent.change(screen.getByTestId("ArticlesForm-title"), {
+        target: { value: "" },
+      });
+      fireEvent.click(screen.getByTestId("ArticlesForm-submit"));
+
+      await screen.findByText(/Title is required/);
+      expect(axiosMock.history.put.length).toBe(0);
+    });
+
+    test("Cancel calls navigate(-1)", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <ArticlesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("ArticlesForm-cancel");
+      fireEvent.click(screen.getByTestId("ArticlesForm-cancel"));
+
+      await waitFor(() =>
+        expect(mockNavigateRelative).toHaveBeenCalledWith(-1),
+      );
+    });
   });
 });


### PR DESCRIPTION
This PR completes the Articles edit flow for /articles/edit/:id. ArticlesEditPage loads one record with GET /api/Articles?id=…, renders ArticlesForm with initialContents and an Update button, submits changes with PUT /api/Articles ( id query param and JSON body: title, url, explanation, email, dateAdded ), shows a success toast, navigates back to /articles after a successful save (unless storybook={true}), and relies on ArticlesForm for validation and Cancel (navigate(-1)).

<img width="1392" height="371" alt="image" src="https://github.com/user-attachments/assets/36103db2-452a-48e1-83b7-bf6f67c505f1" />

<img width="1515" height="745" alt="image" src="https://github.com/user-attachments/assets/d540e740-149a-4c5e-8bf6-e5733549b392" />


Closes #54 