### PR TITLE
Wc ucsb dining commons menu item index page

### DIFF
--- a/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
+++ b/frontend/src/main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.jsx
@@ -1,0 +1,69 @@
+import React from "react";
+import OurTable, { ButtonColumn } from "main/components/OurTable";
+
+import { useBackendMutation } from "main/utils/useBackend";
+import { useNavigate } from "react-router";
+import { hasRole } from "main/utils/useCurrentUser";
+
+const cellToAxiosParamsDelete = (cell) => ({
+  url: "/api/UCSBDiningCommonsMenuItem",
+  method: "DELETE",
+  params: {
+    id: cell.row.original.id,
+  },
+});
+
+const onDeleteSuccess = () => {};
+
+export default function UCSBDiningCommonsMenuItemTable({
+  menuItems,
+  currentUser,
+  testIdPrefix = "UCSBDiningCommonsMenuItemTable",
+}) {
+  const navigate = useNavigate();
+
+  const editCallback = (cell) => {
+    navigate(`/diningcommonsmenuitem/edit/${cell.row.original.id}`);
+  };
+
+  // Stryker disable all : hard to test for query caching
+  const deleteMutation = useBackendMutation(
+    cellToAxiosParamsDelete,
+    { onSuccess: onDeleteSuccess },
+    ["/api/UCSBDiningCommonsMenuItem/all"],
+  );
+  // Stryker restore all
+
+  // Stryker disable next-line all : TODO try to make a good test for this
+  const deleteCallback = async (cell) => {
+    deleteMutation.mutate(cell);
+  };
+
+  const columns = [
+    {
+      header: "id",
+      accessorKey: "id",
+    },
+    {
+      header: "Dining Commons Code",
+      accessorKey: "diningCommonsCode",
+    },
+    {
+      header: "Name",
+      accessorKey: "name",
+    },
+    {
+      header: "Station",
+      accessorKey: "station",
+    },
+  ];
+
+  if (hasRole(currentUser, "ROLE_ADMIN")) {
+    columns.push(ButtonColumn("Edit", "primary", editCallback, testIdPrefix));
+    columns.push(
+      ButtonColumn("Delete", "danger", deleteCallback, testIdPrefix),
+    );
+  }
+
+  return <OurTable data={menuItems} columns={columns} testid={testIdPrefix} />;
+}

--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.jsx
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable";
+import { Button } from "react-bootstrap";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
 
 export default function UCSBDiningCommonsMenuItemIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/diningcommonsmenuitem/create"
+          style={{ float: "right" }}
+        >
+          Create UCSBDiningCommonsMenuItem
+        </Button>
+      );
+    }
+  };
+
+  const {
+    data: menuItems,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/UCSBDiningCommonsMenuItem/all"],
+    { method: "GET", url: "/api/UCSBDiningCommonsMenuItem/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/diningcommonsmenuitem/create">Create</a>
-        </p>
-        <p>
-          <a href="/diningcommonsmenuitem/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>UCSBDiningCommonsMenuItem</h1>
+        <UCSBDiningCommonsMenuItemTable
+          menuItems={menuItems}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.stories.jsx
+++ b/frontend/src/stories/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.stories.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { http, HttpResponse } from "msw";
+
+export default {
+  title: "components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable",
+  component: UCSBDiningCommonsMenuItemTable,
+};
+
+const Template = (args) => {
+  return <UCSBDiningCommonsMenuItemTable {...args} />;
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+  menuItems: [],
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.args = {
+  menuItems: ucsbDiningCommonsMenuItemFixtures.threeMenuItems,
+  currentUser: currentUserFixtures.userOnly,
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.args = {
+  menuItems: ucsbDiningCommonsMenuItemFixtures.threeMenuItems,
+  currentUser: currentUserFixtures.adminUser,
+};
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.delete("/api/UCSBDiningCommonsMenuItem", () => {
+      return HttpResponse.json(
+        { message: "Menu item deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.stories.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage",
+  component: UCSBDiningCommonsMenuItemIndexPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemIndexPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBDiningCommonsMenuItem/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBDiningCommonsMenuItem/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeMenuItems,
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/UCSBDiningCommonsMenuItem/all", () => {
+      return HttpResponse.json(
+        ucsbDiningCommonsMenuItemFixtures.threeMenuItems,
+      );
+    }),
+    http.delete("/api/UCSBDiningCommonsMenuItem", () => {
+      return HttpResponse.json(
+        { message: "UCSBDiningCommonsMenuItem with id 1 deleted" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/components/Nav/Footer.test.jsx
+++ b/frontend/src/tests/components/Nav/Footer.test.jsx
@@ -2,98 +2,78 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import Footer from "main/components/Nav/Footer";
-import { afterEach, expect, beforeEach, vi, describe, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
-// Use doMock and resetModules for isolated mocks.
-// The vi.doMock and vi.resetModules calls should be inside the describe blocks.
+let mockSystemInfo;
 
-const queryClient = new QueryClient();
+vi.mock("main/utils/systemInfo", () => ({
+  useSystemInfo: () => ({
+    data: mockSystemInfo,
+    isSuccess: true,
+  }),
+}));
 
 describe("Footer tests", () => {
-  describe("SystemInfo returns content", () => {
-    beforeEach(() => {
-      // Clears the module cache to ensure each test suite starts fresh.
-      vi.resetModules();
-      queryClient.clear();
-      // Use vi.doMock for an explicit mock that is not hoisted.
-      vi.doMock("main/utils/systemInfo", () => ({
-        useSystemInfo: () => ({
-          data: systemInfoFixtures.initialData,
-          isSuccess: true,
-        }),
-      }));
-    });
+  let queryClient;
 
-    afterEach(() => {
-      vi.clearAllMocks();
-    });
-
-    test("renders correctly with system info content", async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <Footer />
-        </QueryClientProvider>,
-      );
-      // Wait for the query to resolve and content to appear.
-      await waitFor(() => {
-        expect(
-          screen.getByTestId("footer-see-source-code"),
-        ).toBeInTheDocument();
-      });
-
-      const expectedText =
-        "This is a sample webapp using React with a Spring Boot backend. See the source code on Github.";
-
-      expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
-
-      const footer_see_source_code = screen.getByTestId(
-        "footer-see-source-code",
-      );
-      expect(footer_see_source_code).toHaveTextContent(
-        "See the source code on Github.",
-      );
-      const githubLink = screen.getByText(/Github/);
-      expect(githubLink).toBeInTheDocument();
-      expect(githubLink).toHaveAttribute(
-        "href",
-        "https://github.com/ucsb-cs156-s26/STARTER-team02",
-      );
-    });
+  beforeEach(() => {
+    queryClient = new QueryClient();
   });
 
-  describe("SystemInfo is returning null", () => {
-    beforeEach(() => {
-      // Clears the module cache before this test suite as well.
-      vi.resetModules();
-      queryClient.clear();
-      // Use vi.doMock to apply a different mock for this test.
-      vi.doMock("main/utils/systemInfo", () => ({
-        useSystemInfo: () => ({ data: null, isSuccess: true }),
-      }));
+  test("renders correctly with system info content", async () => {
+    mockSystemInfo = systemInfoFixtures.initialData;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Footer />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("Footer")).toBeInTheDocument();
     });
 
-    afterEach(() => {
-      vi.clearAllMocks();
+    const expectedText =
+      "This is a sample webapp using React with a Spring Boot backend. See the source code on Github.";
+
+    expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
+
+    const footer_see_source_code = screen.getByTestId("footer-see-source-code");
+
+    expect(footer_see_source_code).toBeInTheDocument();
+    expect(footer_see_source_code).toHaveTextContent(
+      "See the source code on Github.",
+    );
+
+    const githubLink = screen.getByText(/Github/);
+    expect(githubLink).toBeInTheDocument();
+    expect(githubLink).toHaveAttribute(
+      "href",
+      "https://github.com/ucsb-cs156-s26/STARTER-team02",
+    );
+  });
+
+  test("renders correctly without system info content", async () => {
+    mockSystemInfo = {};
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Footer />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("Footer")).toBeInTheDocument();
     });
 
-    test("renders correctly without system info content", async () => {
-      render(
-        <QueryClientProvider client={queryClient}>
-          <Footer />
-        </QueryClientProvider>,
-      );
-      // Wait for the null data to be processed.
-      await waitFor(() => {
-        const expectedText =
-          "This is a sample webapp using React with a Spring Boot backend.";
-        expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
-      });
+    const expectedText =
+      "This is a sample webapp using React with a Spring Boot backend.";
 
-      const footer_see_source_code = screen.getByTestId(
-        "footer-see-source-code",
-      );
-      expect(footer_see_source_code).toBeInTheDocument();
-      expect(footer_see_source_code).toBeEmpty();
-    });
+    expect(screen.getByTestId("Footer").textContent).toBe(expectedText);
+
+    const footer_see_source_code = screen.getByTestId("footer-see-source-code");
+
+    expect(footer_see_source_code).toBeInTheDocument();
+    expect(footer_see_source_code).toBeEmptyDOMElement();
   });
 });

--- a/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.jsx
+++ b/frontend/src/tests/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable.test.jsx
@@ -1,0 +1,213 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import UCSBDiningCommonsMenuItemTable from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemTable";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = vi.fn();
+vi.mock("react-router", async () => {
+  const originalModule = await vi.importActual("react-router");
+  return {
+    ...originalModule,
+    useNavigate: () => mockedNavigate,
+  };
+});
+
+describe("UCSBDiningCommonsMenuItemTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "Dining Commons Code", "Name", "Station"];
+  const expectedFields = ["id", "diningCommonsCode", "name", "station"];
+  const testId = "UCSBDiningCommonsMenuItemTable";
+
+  test("renders empty table correctly", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemTable
+            menuItems={[]}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(
+        `${testId}-cell-row-0-col-${field}`,
+      );
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemTable
+            menuItems={ucsbDiningCommonsMenuItemFixtures.threeMenuItems}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-diningCommonsCode`),
+    ).toHaveTextContent("ortega");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-name`),
+    ).toHaveTextContent("Baked Pesto Pasta with Chicken");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-station`),
+    ).toHaveTextContent("Entree Specials");
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+    expect(editButton).toHaveClass("btn-primary");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveClass("btn-danger");
+  });
+
+  test("Has the expected column headers and content for ordinary user", () => {
+    const currentUser = currentUserFixtures.userOnly;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemTable
+            menuItems={ucsbDiningCommonsMenuItemFixtures.threeMenuItems}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(cell).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-diningCommonsCode`),
+    ).toHaveTextContent("ortega");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-name`),
+    ).toHaveTextContent("Baked Pesto Pasta with Chicken");
+
+    expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  test("Edit button navigates to the edit page", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemTable
+            menuItems={ucsbDiningCommonsMenuItemFixtures.threeMenuItems}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const editButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Edit-button`,
+    );
+    expect(editButton).toBeInTheDocument();
+
+    fireEvent.click(editButton);
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith(
+        "/diningcommonsmenuitem/edit/1",
+      ),
+    );
+  });
+
+  test("Delete button calls delete callback", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    const axiosMock = new AxiosMockAdapter(axios);
+    axiosMock
+      .onDelete("/api/UCSBDiningCommonsMenuItem")
+      .reply(200, { message: "Menu item deleted" });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemTable
+            menuItems={ucsbDiningCommonsMenuItemFixtures.threeMenuItems}
+            currentUser={currentUser}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(
+      await screen.findByTestId(`${testId}-cell-row-0-col-id`),
+    ).toHaveTextContent("1");
+
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/UCSBDiningCommonsMenuItem",
+    );
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+  });
+});

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage.test.jsx
@@ -1,12 +1,61 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import UCSBDiningCommonsMenuItemIndexPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemIndexPage";
-import { MemoryRouter } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = vi.fn();
+
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
 
 describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
-  const queryClient = new QueryClient();
+  const axiosMock = new AxiosMockAdapter(axios);
+  const testId = "UCSBDiningCommonsMenuItemTable";
 
-  test("renders without crashing", () => {
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    vi.clearAllMocks();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    vi.clearAllMocks();
+
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/UCSBDiningCommonsMenuItem/all").reply(200, []);
+
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -15,18 +64,163 @@ describe("UCSBDiningCommonsMenuItemIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Create UCSBDiningCommonsMenuItem/),
+      ).toBeInTheDocument();
+    });
+
+    const button = screen.getByText(/Create UCSBDiningCommonsMenuItem/);
+    expect(button).toHaveAttribute("href", "/diningcommonsmenuitem/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three menu items correctly for regular user", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+
+    axiosMock
+      .onGet("/api/UCSBDiningCommonsMenuItem/all")
+      .reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
+
     expect(
-      screen.getByText("Index page not yet implemented"),
+      screen.getByText("Baked Pesto Pasta with Chicken"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Tofu Banh Mi Sandwich (v)")).toBeInTheDocument();
+    expect(screen.getByText("Cream of Broccoli Soup (v)")).toBeInTheDocument();
+
+    expect(screen.getAllByText("ortega").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("portola")).toBeInTheDocument();
+
+    expect(
+      screen.getAllByText("Entree Specials").length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Greens & Grains")).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/Create UCSBDiningCommonsMenuItem/),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+
+    axiosMock.onGet("/api/UCSBDiningCommonsMenuItem/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/UCSBDiningCommonsMenuItem/all",
+    );
+
+    restoreConsole();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+    const queryClient = new QueryClient();
+
+    axiosMock
+      .onGet("/api/UCSBDiningCommonsMenuItem/all")
+      .replyOnce(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems);
+
+    axiosMock.onDelete("/api/UCSBDiningCommonsMenuItem").reply(200, {
+      message: "UCSBDiningCommonsMenuItem with id 1 deleted",
+    });
+
+    axiosMock
+      .onGet("/api/UCSBDiningCommonsMenuItem/all")
+      .reply(200, ucsbDiningCommonsMenuItemFixtures.threeMenuItems.slice(1));
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBDiningCommonsMenuItemIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    expect(
+      screen.getByText("Baked Pesto Pasta with Chicken"),
     ).toBeInTheDocument();
 
-    expect(screen.getByText("Create")).toHaveAttribute(
-      "href",
-      "/diningcommonsmenuitem/create",
+    const deleteButton = screen.getByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
     );
+    expect(deleteButton).toBeInTheDocument();
 
-    expect(screen.getByText("Edit")).toHaveAttribute(
-      "href",
-      "/diningcommonsmenuitem/edit/1",
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+
+    expect(axiosMock.history.delete[0].url).toBe(
+      "/api/UCSBDiningCommonsMenuItem",
     );
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Baked Pesto Pasta with Chicken"),
+      ).not.toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
## Overview

This PR implements the index page for `UCSBDiningCommonsMenuItem`.

Closes #8

## Changes

- Replaced the placeholder `UCSBDiningCommonsMenuItemIndexPage` with a real index page.
- The page fetches all records from:
  - `GET /api/UCSBDiningCommonsMenuItem/all`
- The page displays records using `UCSBDiningCommonsMenuItemTable`.
- Admin users can see:
  - `Create UCSBDiningCommonsMenuItem` button
  - Edit buttons
  - Delete buttons
- Regular logged-in users can see the table data only.
- Fixed the table edit route to use:
  - `/diningcommonsmenuitem/edit/:id`
- Added Storybook stories for the index page:
  - Empty
  - ThreeItemsOrdinaryUser
  - ThreeItemsAdminUser
- Added tests for the index page.

## Screenshots
### Local App - Admin View

<img width="1126" height="252" alt="Screenshot 2026-05-05 at 4 00 44 PM" src="https://github.com/user-attachments/assets/d1722913-c494-447c-bc42-cbf73009536c" />

### Local App - Regular User View

<img width="1157" height="237" alt="Screenshot 2026-05-05 at 4 04 57 PM" src="https://github.com/user-attachments/assets/2790cf23-b91e-44ee-8e1b-633d77bf072f" />

### Storybook - Empty

<img width="1113" height="246" alt="Screenshot 2026-05-05 at 4 07 29 PM" src="https://github.com/user-attachments/assets/8949d73b-6114-42a7-a4c6-9e42cd544664" />

###  Storybook - Three Items Ordinary User

<img width="1141" height="467" alt="Screenshot 2026-05-05 at 4 07 39 PM" src="https://github.com/user-attachments/assets/08a1a049-e8ea-41e7-aa89-5696b5e4daee" />

### Storybook - Three Items Admin User

<img width="1144" height="350" alt="Screenshot 2026-05-05 at 4 07 45 PM" src="https://github.com/user-attachments/assets/d4fc81d6-9c0a-454f-9d25-3a07e453c00f" />
