### PR TITLE
Create page for ucsborganization

### DIFF
--- a/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
+++ b/frontend/src/main/pages/UCSBOrganization/UCSBOrganizationCreatePage.jsx
@@ -1,11 +1,47 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBOrganizationForm from "main/components/UCSBOrganization/UCSBOrganizationForm";
+import { Navigate } from "react-router";
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBOrganizationCreatePage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBOrganizationCreatePage({ storybook = false }) {
+  const objectToAxiosParams = (organization) => ({
+    url: "/api/UCSBOrganization/post",
+    method: "POST",
+    params: {
+      orgCode: organization.orgCode,
+      orgTranslationShort: organization.orgTranslationShort,
+      orgTranslation: organization.orgTranslation,
+      inactive: organization.inactive,
+    },
+  });
+
+  const onSuccess = (organization) => {
+    toast(`New UCSBOrganization Created - orgCode: ${organization.orgCode}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/UCSBOrganization/all"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/ucsborganization" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New UCSBOrganization</h1>
+        <UCSBOrganizationForm submitAction={onSubmit} />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBOrganization/UCSBOrganizationCreatePage.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
+
+export default {
+  title: "pages/UCSBOrganization/UCSBOrganizationCreatePage",
+  component: UCSBOrganizationCreatePage,
+};
+
+const Template = () => <UCSBOrganizationCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.post("/api/UCSBOrganization/post", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
+++ b/frontend/src/tests/pages/UCSBOrganization/UCSBOrganizationCreatePage.test.jsx
@@ -1,18 +1,40 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import UCSBOrganizationCreatePage from "main/pages/UCSBOrganization/UCSBOrganizationCreatePage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { expect } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
 
 describe("UCSBOrganizationCreatePage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const setupUserOnly = () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
     axiosMock.reset();
     axiosMock.resetHistory();
     axiosMock
@@ -21,14 +43,11 @@ describe("UCSBOrganizationCreatePage tests", () => {
     axiosMock
       .onGet("/api/systemInfo")
       .reply(200, systemInfoFixtures.showingNeither);
-  };
+  });
 
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    // arrange
-    setupUserOnly();
 
-    // act
+  test("renders without crashing", async () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
@@ -37,10 +56,71 @@ describe("UCSBOrganizationCreatePage tests", () => {
       </QueryClientProvider>,
     );
 
-    // assert
-    await screen.findByText("Create page not yet implemented");
-    expect(
-      screen.getByText("Create page not yet implemented"),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Org Code")).toBeInTheDocument();
+    });
+  });
+
+  test("on submit, makes request to backend, and redirects to /ucsborganization", async () => {
+    const queryClient = new QueryClient();
+    const organization = {
+      orgCode: "ZPRC",
+      orgTranslationShort: "Zeta Phi Rho",
+      orgTranslation: "Zeta Phi Rho Fraternity",
+      inactive: false,
+    };
+
+    axiosMock.onPost("/api/UCSBOrganization/post").reply(202, organization);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UCSBOrganizationCreatePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Org Code")).toBeInTheDocument();
+    });
+
+    const orgCodeInput = screen.getByLabelText("Org Code");
+    expect(orgCodeInput).toBeInTheDocument();
+
+    const orgTranslationShortInput = screen.getByLabelText(
+      "Organization Translation Short",
+    );
+    expect(orgTranslationShortInput).toBeInTheDocument();
+
+    const orgTranslationInput = screen.getByLabelText(
+      "Organization Translation",
+    );
+    expect(orgTranslationInput).toBeInTheDocument();
+
+    const createButton = screen.getByText("Create");
+    expect(createButton).toBeInTheDocument();
+
+    fireEvent.change(orgCodeInput, { target: { value: "ZPRC" } });
+    fireEvent.change(orgTranslationShortInput, {
+      target: { value: "Zeta Phi Rho" },
+    });
+    fireEvent.change(orgTranslationInput, {
+      target: { value: "Zeta Phi Rho Fraternity" },
+    });
+    fireEvent.click(createButton);
+
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(axiosMock.history.post[0].params).toEqual({
+      orgCode: "ZPRC",
+      orgTranslationShort: "Zeta Phi Rho",
+      orgTranslation: "Zeta Phi Rho Fraternity",
+      inactive: false,
+    });
+
+    expect(mockToast).toBeCalledWith(
+      "New UCSBOrganization Created - orgCode: ZPRC",
+    );
+    expect(mockNavigate).toBeCalledWith({ to: "/ucsborganization" });
   });
 });


### PR DESCRIPTION
POSTs to /api/UCSBOrganization/post with orgCode, orgTranslationShort, orgTranslation, inactive as params
Shows a toast on success and navigates to /ucsborganization
Renders UCSBOrganizationForm with the default "Create" button label
UCSBOrganizationCreatePage.test.jsx — 2 tests:

Renders without crashing (form fields visible)
Filling out the form and submitting fires the POST with correct params, shows the toast, and navigates to /ucsborganization

<img width="1161" height="510" alt="Screenshot 2026-05-05 at 4 59 43 PM" src="https://github.com/user-attachments/assets/cee867a5-53a8-4ef9-b94e-8e6bc0f1d37d" />

Closes #16 