### PR TITLE
Add UCSBDiningCommonsMenuItem edit page

### DIFF
--- a/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
+++ b/frontend/src/main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.jsx
@@ -1,11 +1,79 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router";
+import UCSBDiningCommonsMenuItemForm from "main/components/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemForm";
+import { Navigate } from "react-router";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function UCSBDiningCommonsMenuItemEditPage() {
-  // Stryker disable all : placeholder for future implementation
+export default function UCSBDiningCommonsMenuItemEditPage({
+  storybook = false,
+}) {
+  let { id } = useParams();
+
+  const {
+    data: menuItem,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/UCSBDiningCommonsMenuItem`,
+      params: {
+        id,
+      },
+    },
+  );
+
+  const objectToAxiosPutParams = (menuItem) => ({
+    url: "/api/UCSBDiningCommonsMenuItem",
+    method: "PUT",
+    params: {
+      id: menuItem.id,
+    },
+    data: {
+      diningCommonsCode: menuItem.diningCommonsCode,
+      name: menuItem.name,
+      station: menuItem.station,
+    },
+  });
+
+  const onSuccess = (menuItem) => {
+    toast(
+      `UCSBDiningCommonsMenuItem Updated - id: ${menuItem.id} name: ${menuItem.name}`,
+    );
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosPutParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    [`/api/UCSBDiningCommonsMenuItem?id=${id}`],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  };
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/diningcommonsmenuitem" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit page not yet implemented</h1>
+        <h1>Edit UCSBDiningCommonsMenuItem</h1>
+        {menuItem && (
+          <UCSBDiningCommonsMenuItemForm
+            initialContents={menuItem}
+            submitAction={onSubmit}
+            buttonLabel="Update"
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.jsx
+++ b/frontend/src/stories/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.stories.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbDiningCommonsMenuItemFixtures } from "fixtures/ucsbDiningCommonsMenuItemFixtures";
+import { http, HttpResponse } from "msw";
+
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+export default {
+  title: "pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage",
+  component: UCSBDiningCommonsMenuItemEditPage,
+};
+
+const Template = () => <UCSBDiningCommonsMenuItemEditPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/UCSBDiningCommonsMenuItem", () => {
+      return HttpResponse.json(ucsbDiningCommonsMenuItemFixtures.oneMenuItem, {
+        status: 200,
+      });
+    }),
+    http.put("/api/UCSBDiningCommonsMenuItem", () => {
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
+++ b/frontend/src/tests/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage.test.jsx
@@ -1,22 +1,234 @@
-import { render, screen } from "@testing-library/react";
-import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import UCSBDiningCommonsMenuItemEditPage from "main/pages/UCSBDiningCommonsMenuItem/UCSBDiningCommonsMenuItemEditPage";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import mockConsole from "tests/testutils/mockConsole";
+import { beforeEach, afterEach } from "vitest";
+
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock("react-router", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    useParams: vi.fn(() => ({
+      id: 17,
+    })),
+    Navigate: vi.fn((x) => {
+      mockNavigate(x);
+      return null;
+    }),
+  };
+});
+
+let axiosMock;
 
 describe("UCSBDiningCommonsMenuItemEditPage tests", () => {
-  test("renders without crashing", () => {
+  describe("when the backend doesn't return data", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } })
+        .timeout();
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
     const queryClient = new QueryClient();
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <UCSBDiningCommonsMenuItemEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+    test("renders header but form is not present", async () => {
+      const restoreConsole = mockConsole();
 
-    expect(
-      screen.getByText("Edit page not yet implemented"),
-    ).toBeInTheDocument();
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByText("Edit UCSBDiningCommonsMenuItem");
+      expect(
+        screen.queryByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode"),
+      ).not.toBeInTheDocument();
+
+      restoreConsole();
+    });
+  });
+
+  describe("tests where backend is working normally", () => {
+    beforeEach(() => {
+      axiosMock = new AxiosMockAdapter(axios);
+      axiosMock.reset();
+      axiosMock.resetHistory();
+
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/UCSBDiningCommonsMenuItem", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          diningCommonsCode: "ortega",
+          name: "Baked Pesto Pasta with Chicken",
+          station: "Entree Specials",
+        });
+      axiosMock.onPut("/api/UCSBDiningCommonsMenuItem").reply(200, {
+        id: 17,
+        diningCommonsCode: "portola",
+        name: "Cream of Broccoli Soup",
+        station: "Greens & Grains",
+      });
+    });
+
+    afterEach(() => {
+      mockToast.mockClear();
+      mockNavigate.mockClear();
+      axiosMock.restore();
+      axiosMock.resetHistory();
+    });
+
+    const queryClient = new QueryClient();
+
+    test("renders without crashing", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      expect(
+        screen.getByTestId("UCSBDiningCommonsMenuItemForm-diningCommonsCode"),
+      ).toBeInTheDocument();
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-name",
+      );
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-submit",
+      );
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("ortega");
+      expect(nameField).toHaveValue("Baked Pesto Pasta with Chicken");
+      expect(stationField).toHaveValue("Entree Specials");
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).toHaveTextContent("Update");
+    });
+
+    test("Changes when you click Update", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <UCSBDiningCommonsMenuItemEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+
+      const idField = screen.getByTestId("UCSBDiningCommonsMenuItemForm-id");
+      const diningCommonsCodeField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-diningCommonsCode",
+      );
+      const nameField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-name",
+      );
+      const stationField = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-station",
+      );
+      const submitButton = screen.getByTestId(
+        "UCSBDiningCommonsMenuItemForm-submit",
+      );
+
+      expect(idField).toHaveValue("17");
+      expect(diningCommonsCodeField).toHaveValue("ortega");
+      expect(nameField).toHaveValue("Baked Pesto Pasta with Chicken");
+      expect(stationField).toHaveValue("Entree Specials");
+
+      fireEvent.change(diningCommonsCodeField, {
+        target: { value: "portola" },
+      });
+      fireEvent.change(nameField, {
+        target: { value: "Cream of Broccoli Soup" },
+      });
+      fireEvent.change(stationField, {
+        target: { value: "Greens & Grains" },
+      });
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "UCSBDiningCommonsMenuItem Updated - id: 17 name: Cream of Broccoli Soup",
+      );
+      expect(mockNavigate).toBeCalledWith({ to: "/diningcommonsmenuitem" });
+
+      expect(axiosMock.history.put.length).toBe(1);
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          diningCommonsCode: "portola",
+          name: "Cream of Broccoli Soup",
+          station: "Greens & Grains",
+        }),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

This PR adds the edit page for UCSBDiningCommonsMenuItem.

Changes include:
- Replaced the placeholder edit page with a working edit page
- Added GET support to load one UCSBDiningCommonsMenuItem by id
- Added PUT support to update an existing UCSBDiningCommonsMenuItem
- Added tests for the edit page
- Added a Storybook entry for the edit page

## Screenshots

<img width="1381" height="494" alt="Screenshot 2026-05-05 at 5 55 37 PM" src="https://github.com/user-attachments/assets/16172562-64c2-441f-94da-8838a464d394" />
<img width="864" height="810" alt="Screenshot 2026-05-05 at 5 55 05 PM" src="https://github.com/user-attachments/assets/d3421527-d248-4562-af77-eac7f8e1daed" />

## Closes #9
