### PR TITLE
Add UCSBOrganization end-to-end test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
@@ -1,0 +1,59 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBOrganizationWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_organization() throws Exception {
+    setupUser(true);
+
+    page.getByText("UCSBOrganization").click();
+
+    page.getByText("Create UCSBOrganization").click();
+    assertThat(page.getByText("Create New UCSBOrganization")).isVisible();
+
+    page.getByTestId("UCSBOrganizationForm-orgCode").fill("ZPR");
+    page.getByTestId("UCSBOrganizationForm-orgTranslationShort").fill("ZETA PHI RHO");
+    page.getByTestId("UCSBOrganizationForm-orgTranslation").fill("ZETA PHI RHO");
+    page.getByTestId("UCSBOrganizationForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).hasText("ZPR");
+
+    page.getByTestId("UCSBOrganizationTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit UCSBOrganization")).isVisible();
+
+    page.getByTestId("UCSBOrganizationForm-orgTranslationShort").fill("ZETA PHI RHO UPDATED");
+    page.getByTestId("UCSBOrganizationForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgTranslationShort"))
+        .hasText("ZETA PHI RHO UPDATED");
+
+    page.getByTestId("UCSBOrganizationTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).not().isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_organization() throws Exception {
+    setupUser(false);
+
+    page.getByText("UCSBOrganization").click();
+
+    assertThat(page.getByText("Create UCSBOrganization")).not().isVisible();
+    assertThat(page.getByText("Edit")).not().isVisible();
+    assertThat(page.getByText("Delete")).not().isVisible();
+  }
+}


### PR DESCRIPTION
Adds end-to-end tests for the UCSBOrganization frontend pages. Tests that an admin user can create, edit, and delete an organization through the UI, and that a regular user cannot see the Create/Edit/Delete buttons.

Closes #116 