### PR TITLE
Add Articles end-to-end test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/ArticleWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/ArticleWebIT.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class ArticleWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_edit_delete_article() throws Exception {
+    setupUser(true);
+
+    page.getByText("Articles").click();
+
+    page.getByText("Create Article").click();
+    assertThat(page.getByText("Create New Article")).isVisible();
+
+    page.getByTestId("ArticlesForm-title")
+        .fill("Using testing-playground with React Testing Library");
+    page.getByTestId("ArticlesForm-url")
+        .fill("https://dev.to/katieraby/using-testing-playground-with-react-testing-library-26j7");
+    page.getByTestId("ArticlesForm-explanation")
+        .fill("Helpful when we get to front end development");
+    page.getByTestId("ArticlesForm-email").fill("phtcon@ucsb.edu");
+    page.getByTestId("ArticlesForm-dateAdded").fill("2022-04-20T00:00");
+    page.getByTestId("ArticlesForm-submit").click();
+
+    assertThat(page.getByTestId("ArticlesTable-cell-row-0-col-title"))
+        .hasText("Using testing-playground with React Testing Library");
+
+    page.getByTestId("ArticlesTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit Article")).isVisible();
+
+    page.getByTestId("ArticlesForm-title").fill("Handy Spring Utility Classes");
+    page.getByTestId("ArticlesForm-submit").click();
+
+    assertThat(page.getByTestId("ArticlesTable-cell-row-0-col-title"))
+        .hasText("Handy Spring Utility Classes");
+
+    page.getByTestId("ArticlesTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("ArticlesTable-cell-row-0-col-title")).not().isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_article() throws Exception {
+    setupUser(false);
+
+    page.getByText("Articles").click();
+
+    assertThat(page.getByText("Create Article")).not().isVisible();
+    assertThat(page.getByText("Edit")).not().isVisible();
+    assertThat(page.getByText("Delete")).not().isVisible();
+  }
+}


### PR DESCRIPTION
Adds `ArticleWebIT.java` with two Playwright end-to-end tests for the Articles frontend, modeled after `RestaurantWebIT.java`: one admin test exercising the full create/edit/delete CRUD flow through the UI, and one non-admin test asserting that Create/Edit/Delete controls are hidden. Both pass via `INTEGRATION=true mvn failsafe:integration-test -Dit.test=ArticleWebIT`.

Closes #120 